### PR TITLE
Fix number parsing + Windows build script tweaks

### DIFF
--- a/src/rust/wpcomics/build.ps1
+++ b/src/rust/wpcomics/build.ps1
@@ -40,7 +40,7 @@ function Package-Source {
         Copy-Item sources/$source/res/* target/wasm32-unknown-unknown/release/Payload -ErrorAction SilentlyContinue
         Set-Location target/wasm32-unknown-unknown/release
         Copy-Item "$source.wasm" Payload/main.wasm
-        zip -rq "../../../$source.aix" Payload
+        Compress-Archive -Force -Path Payload -DestinationPath "../../../$source.aix"
         Remove-Item -Recurse -Force Payload/
         Set-Location ../../..
     }

--- a/src/rust/wpcomics/sources/xoxocomics/src/lib.rs
+++ b/src/rust/wpcomics/sources/xoxocomics/src/lib.rs
@@ -20,7 +20,6 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
                 match filter.name.as_str() {
                     "Genre" => {
                         genre = get_tag_id(filter.value.as_int().unwrap_or(0));
-                        println!("genre: {}", genre);
                     },
                     _ => continue,
                 }

--- a/src/rust/wpcomics/template/src/helper.rs
+++ b/src/rust/wpcomics/template/src/helper.rs
@@ -10,8 +10,16 @@ macro_rules! scan {
     }}
 }
 
-pub fn extract_i32_from_string(title: String, text: String) -> String {  
-    text.replace(&title, "").chars().filter(|a| (*a >= '0' && *a <= '9') || *a == ' ').collect::<String>()
+pub fn extract_i32_from_string(title: String, text: String) -> f32 {  
+    text.replace(&title, "")
+        .chars()
+        .filter(|a| (*a >= '0' && *a <= '9') || *a == ' ' || *a == '.')
+        .collect::<String>()
+        .split(" ")
+        .collect::<Vec<&str>>().into_iter()
+        .map(|a| a.parse::<f32>().unwrap_or(0.0))
+        .find(|a| *a > 0.0)
+        .unwrap_or(0.0)
 }
 
 pub fn append_protocol(url: String) -> String {

--- a/src/rust/wpcomics/template/src/helper.rs
+++ b/src/rust/wpcomics/template/src/helper.rs
@@ -10,7 +10,7 @@ macro_rules! scan {
     }}
 }
 
-pub fn extract_i32_from_string(title: String, text: String) -> f32 {  
+pub fn extract_f32_from_string(title: String, text: String) -> f32 {  
     text.replace(&title, "")
         .chars()
         .filter(|a| (*a >= '0' && *a <= '9') || *a == ' ' || *a == '.')

--- a/src/rust/wpcomics/template/src/template.rs
+++ b/src/rust/wpcomics/template/src/template.rs
@@ -3,7 +3,7 @@ use aidoku::{
     Listing, Manga, MangaPageResult, Page, MangaStatus, MangaContentRating, MangaViewer, Chapter, DeepLink
 };
 
-use crate::helper::{i32_to_string, append_protocol, https_upgrade, extract_i32_from_string};
+use crate::helper::{i32_to_string, append_protocol, https_upgrade, extract_f32_from_string};
 
 pub fn get_manga_list(search_url: String, next_page_selector: String, title_transformer: fn(String) -> String) -> Result<MangaPageResult> {
     let mut mangas: Vec<Manga> = Vec::new();
@@ -104,7 +104,7 @@ pub fn get_chapter_list(id: String, title_transformer: fn(String) -> String, ski
         let chapter_url = chapter_node.select("div.chapter > a").attr("href").read().replacen("http://", "https://", 1);
         let chapter_id = chapter_url.clone();
         let chapter_title = chapter_node.select("div.chapter > a").text().read();
-        let chapter_number = extract_i32_from_string(String::from(title), String::from(&chapter_title));
+        let chapter_number = extract_f32_from_string(String::from(title), String::from(&chapter_title));
         let date_updated = chapter_date_converter(chapter_node.select(&chapter_date_selector).text().read());
         chapters.push(Chapter {
             id: chapter_id,

--- a/src/rust/wpcomics/template/src/template.rs
+++ b/src/rust/wpcomics/template/src/template.rs
@@ -104,13 +104,13 @@ pub fn get_chapter_list(id: String, title_transformer: fn(String) -> String, ski
         let chapter_url = chapter_node.select("div.chapter > a").attr("href").read().replacen("http://", "https://", 1);
         let chapter_id = chapter_url.clone();
         let chapter_title = chapter_node.select("div.chapter > a").text().read();
-        let chapter_number = extract_i32_from_string(String::from(title), String::from(&chapter_title)).split(" ").collect::<Vec<&str>>().into_iter().map(|a| a.parse::<f32>().unwrap_or(0.0)).find(|a| *a > 0.0);
+        let chapter_number = extract_i32_from_string(String::from(title), String::from(&chapter_title));
         let date_updated = chapter_date_converter(chapter_node.select(&chapter_date_selector).text().read());
         chapters.push(Chapter {
             id: chapter_id,
             title: chapter_title,
             volume: -1.0,
-            chapter: chapter_number.unwrap_or(-1.0),
+            chapter: chapter_number,
             date_updated,
             scanlator: String::new(),
             url: chapter_url,


### PR DESCRIPTION
- Fix decimal chapter extraction (`Chapter 13.5` no longer gets converted to `Ch.135`)
- Windows build script use all native cmdlets, so the only thing required is `cargo`.