### PR TITLE
fix(wpcomics): copy default filter template

### DIFF
--- a/src/rust/wpcomics/build.sh
+++ b/src/rust/wpcomics/build.sh
@@ -7,6 +7,7 @@ if [ "$1" != "-a" ] && [ "$1" != "" ]; then
 	
 	echo "packaging $1";
 	mkdir -p target/wasm32-unknown-unknown/release/Payload
+	cp res/* target/wasm32-unknown-unknown/release/Payload
 	cp sources/$1/res/* target/wasm32-unknown-unknown/release/Payload
 	cd target/wasm32-unknown-unknown/release
 	cp $1.wasm Payload/main.wasm
@@ -24,6 +25,7 @@ else
 		echo "packaging $dir";
 
 		mkdir -p target/wasm32-unknown-unknown/release/Payload
+		cp res/* target/wasm32-unknown-unknown/release/Payload
 		cp sources/$dir/res/* target/wasm32-unknown-unknown/release/Payload
 		cd target/wasm32-unknown-unknown/release
 		cp $dir.wasm Payload/main.wasm


### PR DESCRIPTION
yeah that's it. fixes xoxocomics and other sources that use the default filter template.