### PR TITLE
Add contribution guide and dual-license (Apache-2.0 OR MIT)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,325 @@
+# Contributing
+This guide outlines how to create a new Aidoku source. Please read it **carefully** before you get started, or if you don't have any experience on the required languages and tooling.
+
+This guide is not definitive by any means. If you find any issue, report it by [creating an issue](https://github.com/Skittyblock/aidoku-community-sources/issues/new) or submit a pull request directly.
+
+## Table of contents
+1. [Prerequisites](#prerequisites)
+2. [Getting help](#getting-help)
+3. [Writing a source](#writing-a-source)
+  1. [File structure](#file-structure)
+  2. [Dependencies](#dependencies)
+  3. [Exported functions](#exported-functions)
+  4. [Notes](#notes)
+4. [Template sources](#template-sources)
+  1. [Directory structure](#directory-structure)
+5. [Running](#running)
+6. [Debugging](#debugging)
+  1. [Good old print statements](#good-old-print-statements)
+  2. [Inspecting network calls](#inspecting-network-calls)
+7. [Submitting the changes](#submitting-changes)
+  1. [Pull Request checklist](#pull-request-checklist)
+
+## Prerequisites
+Before you start, please note that basic knowledge in these technologies is **required**.
+- One of these programming languages:
+  - [Rust](https://doc.rust-lang.org/book/) (preferred)
+  - [AssemblyScript](https://www.assemblyscript.org/introduction.html), a variant of TypeScript
+  - The C programming language
+- Web scraping:
+  - [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML)
+  - [CSS selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors)
+
+### Tooling
+- An iOS device/simulator with a recent version of Aidoku
+- [aidoku-cli](https://github.com/Aidoku/aidoku-cli) (optional, recommended if you're not developing on a macOS machine)
+- Basic image editing knowledge
+
+### Cloning the repository
+Some steps can be taken to ignore the `gh-pages` branch and skip unrelated sources, which reduces time taken to pull and navigate. This will also reduce disk usage and network traffic.
+
+<details>
+    <summary>Steps</summary>
+
+1. Delete the `gh-pages` branch in your repo. You may also want to disable GitHub Actions in the repo settings.
+2. Do a partial clone:
+```sh
+git clone --filter=blob:none --no-checkout <fork-repo-url>
+cd aidoku-community-sources/
+```
+3. Enable sparse checkout:
+```sh
+git sparse-checkout set
+```
+4. Edit `.git/info/sparse-checkout` to filter checked out paths. Here's an example:
+```sh
+/*
+!/src
+
+# (optional) ignore the C bindings if you're not working with C 
+!/lib
+
+# Allow a single source
+/src/<lang>/<source>
+```
+5. Configure remotes:
+```sh
+git remote add upstream https://github.com/Skittyblock/aidoku-community-sources
+
+# Optionally disable pushing to upstream
+git remote set-url --push upstream no_pushing
+
+# Only fetch upstream's main branch
+git config remote.upstream.fetch "+refs/heads/main:refs/remotes/upstream/main"
+
+# Update remotes
+git remote update
+
+# Track upstream's main branch
+git branch main -u upstream/main
+
+# Switch to main branch
+git switch main
+```
+6. Optional useful configuration:
+```sh
+# prune obsolete remote branches on fetch
+git config remote.origin.prune true
+
+# fast-forward only when pulling master branch
+git config pull.ff only
+```
+
+If you change the sparse checkout filter later, run `git sparse-checkout reapply`.
+
+Read more on [partial clone](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/), [sparse checkout](https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/) and [negative refspecs](https://github.blog/2020-10-19-git-2-29-released/#user-content-negative-refspecs).
+</details>
+
+## Getting help
+- Join [the Discord server](https://discord.com/invite/9U8cC5Zk3s) to ask questions while developing your source. Please do so in the `#source-dev` channel.
+
+## Writing a source
+The fastest way to get started is to either copy an existing source and renaming as needed, or using [aidoku-cli](https://github.com/Aidoku/aidoku-cli). 
+
+Run `aidoku init` and there should be an interactive wizard for scaffolding a source. The `rust-template` template is for websites that share common code, while the `rust` template is for developing a single source.
+
+Each source should be in `src/<lang>/<source-language>.<source-name>`:
+- The `<lang>` part is the programming language your source is developed in, so `as` for AssemblyScript, `rust` for Rust, and so on. 
+- `<source-language>`: Use `multi` if your source supports multiple languages, or omit if it's a template source.
+`<source-language>` should contain the full locale string in lowercase. For example, if you're creating a Portugese (Brazilian) source, use `pt-br`.
+
+### File structure
+A simple Rust source structure looks like this:
+```sh
+$ tree src/rust/<sourcename>/
+src/rust/<sourcename>/   
+├── build.ps1
+├── build.sh
+├── Cargo.lock
+├── Cargo.toml
+├── res
+│   ├── filters.json
+│   ├── Icon.png
+│   └── settings.json
+│   └── source.json
+└── src
+    ├── helper.rs
+    └── lib.rs
+```
+
+#### source.json
+A minimal manifest which describes the source to Aidoku. Make sure it follows this structure:
+```json
+{
+    "info": {
+        "id": "<lang>.<sourcename>",
+        "lang": "<lang>",
+        "name": "<My source name>",
+        "version": 1,
+        "url": "<Source URL>",
+        "urls": [
+            "<Source URL>",
+            "<Additional source URLs>"
+        ],
+        "nsfw": 1
+    },
+    "languages": [
+        { "code": "<lang>" },
+        { "code": "<lang2>" },
+    ],
+    "listings": [
+        { "name": "<Listing name>" }
+    ]
+}
+```
+| Field          | Description                                                                                                                        |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------|
+| `info.id`      | A unique identifier for the source. The language and the site name should be enough.                                               |
+| `info.lang`    | The source's language.                                                                                                             |
+| `info.name`    | The displayed name of the source.                                                                                                  |
+| `info.version` | The source's version number. It must be a positive integer and incremented with any notable changes.                               |
+| `info.url`     | The source's main URL, which can be used for [deep linking](#handleurl).                                                        |
+| `info.urls`    | Any additional URLs used for [deep linking](#deep-linking). If `info.url` isn't available, the first item is used as the main URL. |
+| `info.nsfw`    | The NSFW level of the source. `0` for sources with no NSFW content at all, `1` for some NSFW, and `2` for majority NSFW sources.   |
+| `languages`    | An array of languages that the source supports. Use on multi-language sources only.                                                |
+| `listings`     | An array of listings that the source supports outside of the default `All` listing. These extra listings are not filterable.       |
+
+#### settings.json
+Expose user settings by declaring them in this file. See this [gist](https://gist.github.com/beerpiss/18e0a861a55f6fa9ed6733798f027ee0) for more information.
+
+#### filters.json
+Aidoku supports search filters which are declared in this file. 
+
+### Dependencies
+Sources rely on bindings for their respective languages:
+- Rust: [aidoku-rs](https://github.com/Aidoku/aidoku-rs)
+- AssemblyScript: [aidoku-as](https://github.com/Aidoku/aidoku-as)
+- C bindings are [here](https://github.com/Skittyblock/aidoku-community-sources/tree/main/lib/c)
+
+### Exported functions
+#### `initialize`
+Called once on source startup. Use it to do any initialization work (e.g. setting the rate limit).
+
+#### `get_manga_list`
+a.k.a the All listing.
+
+- The app calls `get_manga_list` which should return a `MangaPageResult` containing a batch of found `Manga` entries.
+  - This function supports pagination. When the user finishes scrolling the first batch and more results need to be fetched, the app calls this function again with increasing `page` values starting from `1`. This continues until the source returns `MangaPageResult.has_more` as `false`.
+  - When the user searches inside the app, this function will be called with an array of filters passed. If search functionality is not available, remove the [`filters.json`](#filtersjson) file.
+- To show the list properly, the app needs at least `Manga.title` and `Manga.id` set. The rest of the fields can be filled later.
+
+#### `get_manga_listing`
+Invoked for any other listing outside "All". Similar process to `get_manga_list`, but does not support filtering.
+
+#### `get_manga_details`
+When the user taps on a manga, this function will be called with the manga's ID to update a manga's details.
+- If a manga is cached, this function is invoked if the user does a manual update (pull-to-refresh).
+
+#### `get_chapter_list`
+Function is called to display the chapter list after `get_manga_details` is done. **The list should be sorted descending by the source order.**
+
+- `Chapter.date_updated` is the [UNIX epoch time](https://en.wikipedia.org/wiki/Unix_time) expressed in **seconds**.
+    - If this attribute is less than or equal to zero, the app won't display date updated.
+    - To get the time in seconds from a date string, use `ValueRef.as_date` (Rust) or `ValueRef.toDate` (AssemblyScript). The date format must be compatible with [NSDateFormatter](https://nsdateformatter.com/).
+    - If there is any problem parsing, return `-1`.
+
+#### `get_page_list`
+- When the user opens a chapter, `get_page_list` will be called and it should return a list of `Page`s.
+- Currently, the source must provide all the page images directly, and they **must be set as an absolute URL**.
+- Chapter page numbers start from 0.
+
+#### `handle_url`
+When a source URL is opened with Aidoku, this function will be called and it returns a `DeepLink` object containing the manga and chapter that the URL pointed to.
+
+#### `handle_notification`
+Used for handling any [setting](#settingsjson) changes.
+
+### Notes
+- You probably want to percent-encode any user input that goes in the URL (e.g. title search). If you scaffolded a source using aidoku-cli, there's already a helper function called `urlencode`. If there isn't, check existing sources for an implementation.
+
+## Template sources
+Multiple source sites may use the same site generator tool (usually a content management system), and so it makes sense to reuse code.
+
+The **template** contains the base implementation, and then each source defines its own implementation upon that base, which then is used to generate individual sources from.
+
+### Directory structure
+```sh
+$ ls src/rust/<template>
+src/rust/<template>
+├── build.ps1
+├── build.sh
+├── res
+├── sources
+│   └── <sourcename>
+└── template
+    └── src
+        ├── template.rs
+        ├── lib.rs
+        └── helper.rs
+```
+- `build.ps1` and `build.sh` are the template build scripts
+  - Call them with no arguments (or `-a`) to build all sources
+  - Call them with a `<sourcename>` to build the source package for that website.
+- `<template>/template` defines the template's default implementation.
+- `res` is the template's default resources (filters, icons, etc.). If a source doesn't have their own resources, then the default will be used.
+- `sources` are the implementations for sources using the template.
+
+## Running
+To make development more convenient on non-Apple devices, you can use `aidoku serve` from [aidoku-cli](https://github.com/Aidoku/aidoku-cli) to create a local source list:
+```sh
+$ aidoku serve *.aix
+Listening on these addresses:
+  # A list of IP addresses will be displayed here.
+  # Pick the one which looks the most like your local network's IP address 
+  # and add it to Aidoku (assuming your development machine and your device
+  # is on the same network).
+  #
+  # To make picking addresses easier, addresses that looks like your local IP
+  # address are highlighted in green.
+Hit CTRL-C to stop the server
+```
+
+## Debugging
+### Good old print statements
+You can use `aidoku::prelude::println!` (Rust) or `console.log` (AssemblyScript) to print messages that will show up in Aidoku logs (Aidoku -> Settings -> Display Logs). These logs also show up in the console if you're running Aidoku in the Xcode simulator.
+
+Alternatively, use `aidoku logcat` from [aidoku-cli](https://github.com/Aidoku/aidoku-cli) to stream logs to your development machine:
+```sh
+$ aidoku logcat
+Listening on these addresses:
+  # A list of IP addresses will be displayed here.
+  # Pick the one which looks the most like your local network's IP address 
+  # and edit the Log Server option in Aidoku with that address.
+  #
+  # To make picking addresses easier, addresses that looks like your local IP
+  # address are highlighted in green.
+```
+
+### Inspecting network calls
+If you want to take a look into the network flow, you can use a web debugging tool.
+
+#### Setup your proxy server
+We are going to use [mitmproxy](https://mitmproxy.org/) but any web debugger (e.g. Charles, Fiddler) is fine. To install and execute, run the commands below:
+```sh
+# Install the tool. If you don't have Python 3 installed, do it first.
+$ sudo pip3 install mitmproxy
+# Execute the web interface and the proxy.
+$ mitmweb
+```
+After running, navigate to http://localhost:8081 from your browser.
+
+Then edit your device's network settings by navigating to Settings -> Wi-Fi -> `<your network name>` -> Proxy and set configuration to Manual. Set the address to your machine's address, and the port to 8081.
+
+If all went well, you should see all requests and responses made by the source in the web interface of `mitmweb`.
+
+## Submitting changes
+When you feel confident about your changes, submit a new Pull Request so your code can be reviewed and merged if it's approved. We encourage following a [GitHub Standard Fork & Pull Request Workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962) and following the good practices of the workflow, such as not commiting directly to `main`: always create a new branch for your changes.
+
+Please test your changes by running the source on a simulator or a test device before submitting it. Also make sure to follow the PR checklist available in the PR body field when creating a new PR. As a reference, you can find it below.
+
+### Pull Request checklist
+Checklist:
+- [ ] Updated source's version for individual source changes
+- [ ] Updated all sources' versions for template changes
+- [ ] Set appropriate `nsfw` value
+- [ ] Did not change `id` even if a source's name or language were changed
+- [ ] Tested the modifications by running it on the simulator or a test device 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Read more on [partial clone](https://github.blog/2020-12-21-get-up-to-speed-with
 - Join [the Discord server](https://discord.com/invite/9U8cC5Zk3s) to ask questions while developing your source. Please do so in the `#source-dev` channel.
 
 ## Writing a source
-The fastest way to get started is to either copy an existing source and renaming as needed, or using `aidoku init` from [aidoku-cli](https://github.com/Aidoku/aidoku-cli). You should also reading through a few existing sources' code before you start.
+The fastest way to get started is to either copy an existing source and renaming as needed, or using `aidoku init` from [aidoku-cli](https://github.com/Aidoku/aidoku-cli). You should also read through a few existing sources' code before you start.
 
 Each source should be in `src/<lang>/<source-language>.<source-name>`:
 - The `<lang>` part is the programming language your source is developed in, so `as` for AssemblyScript, `rust` for Rust, and so on. 
@@ -156,8 +156,8 @@ A minimal manifest which describes the source to Aidoku. Make sure it follows th
 | `info.lang`    | The source's language.                                                                                                             |
 | `info.name`    | The displayed name of the source.                                                                                                  |
 | `info.version` | The source's version number. It must be a positive integer and incremented with any notable changes.                               |
-| `info.url`     | The source's main URL, which can be used for [deep linking](#handleurl).                                                        |
-| `info.urls`    | Any additional URLs used for [deep linking](#deep-linking). If `info.url` isn't available, the first item is used as the main URL. |
+| `info.url`     | The source's main URL, which can be used for [deep linking](#handle_url).                                                        |
+| `info.urls`    | Any additional URLs used for [deep linking](#handle_url). If `info.url` isn't available, the first item is used as the main URL. |
 | `info.nsfw`    | The NSFW level of the source. `0` for sources with no NSFW content at all, `1` for some NSFW, and `2` for majority NSFW sources.   |
 | `languages`    | An array of languages that the source supports. Use on multi-language sources only.                                                |
 | `listings`     | An array of listings that the source supports outside of the default `All` listing. These extra listings are not filterable.       |
@@ -287,6 +287,8 @@ $ mitmweb
 After running, navigate to http://localhost:8081 from your browser.
 
 Then edit your device's network settings by navigating to Settings -> Wi-Fi -> `<your network name>` -> Proxy and set configuration to Manual. Set the address to your machine's address, and the port to 8081.
+    
+Afterwards, visit [mitm.it](http://mitm.it) to install the mitmproxy certificate, which is required when proxying HTTPS traffic. Refer to [this link](https://docs.mitmproxy.org/stable/concepts-certificates/) for more details.
 
 If all went well, you should see all requests and responses made by the source in the web interface of `mitmweb`.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,18 +7,18 @@ This guide is not definitive by any means. If you find any issue, report it by [
 1. [Prerequisites](#prerequisites)
 2. [Getting help](#getting-help)
 3. [Writing a source](#writing-a-source)
-  1. [File structure](#file-structure)
-  2. [Dependencies](#dependencies)
-  3. [Exported functions](#exported-functions)
-  4. [Notes](#notes)
+    1. [File structure](#file-structure)
+    2. [Dependencies](#dependencies)
+    3. [Exported functions](#exported-functions)
+    4. [Notes](#notes)
 4. [Template sources](#template-sources)
-  1. [Directory structure](#directory-structure)
+    1. [Directory structure](#directory-structure)
 5. [Running](#running)
 6. [Debugging](#debugging)
-  1. [Good old print statements](#good-old-print-statements)
-  2. [Inspecting network calls](#inspecting-network-calls)
+    1. [Good old print statements](#good-old-print-statements)
+    2. [Inspecting network calls](#inspecting-network-calls)
 7. [Submitting the changes](#submitting-changes)
-  1. [Pull Request checklist](#pull-request-checklist)
+    1. [Pull Request checklist](#pull-request-checklist)
 
 ## Prerequisites
 Before you start, please note that basic knowledge in these technologies is **required**.
@@ -99,9 +99,7 @@ Read more on [partial clone](https://github.blog/2020-12-21-get-up-to-speed-with
 - Join [the Discord server](https://discord.com/invite/9U8cC5Zk3s) to ask questions while developing your source. Please do so in the `#source-dev` channel.
 
 ## Writing a source
-The fastest way to get started is to either copy an existing source and renaming as needed, or using [aidoku-cli](https://github.com/Aidoku/aidoku-cli). 
-
-Run `aidoku init` and there should be an interactive wizard for scaffolding a source. The `rust-template` template is for websites that share common code, while the `rust` template is for developing a single source.
+The fastest way to get started is to either copy an existing source and renaming as needed, or using `aidoku init` from [aidoku-cli](https://github.com/Aidoku/aidoku-cli). You should also reading through a few existing sources' code before you start.
 
 Each source should be in `src/<lang>/<source-language>.<source-name>`:
 - The `<lang>` part is the programming language your source is developed in, so `as` for AssemblyScript, `rust` for Rust, and so on. 
@@ -304,22 +302,3 @@ Checklist:
 - [ ] Set appropriate `nsfw` value
 - [ ] Did not change `id` even if a source's name or language were changed
 - [ ] Tested the modifications by running it on the simulator or a test device 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,18 @@
+Copyright 2022 Aidoku community source contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Aidoku Sources
 This repository hosts the public sources that are installable directly through the Aidoku application.
+
+## Usage
+[Add this source list](https://aidoku.app/add-source-list/?url=https://raw.githubusercontent.com/Skittyblock/aidoku-community-sources/gh-pages/) to the Aidoku app.
+
+## Contributing
+Contributions are welcome!
+
+See [CONTRIBUTING.md](./.github/CONTRIBUTING.md) to get started with development.
+
+## License
+Licensed under either of Apache License, version 2.0 or MIT license at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this repository by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
### Description
- Add a contribution guide
- Dual license under either of Apache 2.0 or MIT. This is what many Rust projects do, so I figured this choice would be fitting. Need all contributors to be on board though.