### PR TITLE
Changed source-path string

### DIFF
--- a/src/rust/madara/sources/resetscans/res/source.json
+++ b/src/rust/madara/sources/resetscans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.resetscans",
 		"lang": "en",
 		"name": "Reset Scans",
-		"version": 4,
+		"version": 5,
 		"url": "https://reset-scans.com",
 		"nsfw": 0
 	},

--- a/src/rust/madara/sources/resetscans/src/lib.rs
+++ b/src/rust/madara/sources/resetscans/src/lib.rs
@@ -9,6 +9,7 @@ use madara_template::template;
 fn get_data() -> template::MadaraSiteData {
 	let data: template::MadaraSiteData = template::MadaraSiteData {
 		base_url: String::from("https://reset-scans.com"),
+		source_path: String::from("devmax"),
 		alt_ajax: true,
 		..Default::default()
 	};


### PR DESCRIPTION
changed from manga to devmax
reset-scans.com/devmax/mangaid

Should not affect ids

Checklist:
- [x] Updated source's version for individual source changes
- [x] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
