### PR TITLE
fix(luminousscans): update path name again

### DIFF
--- a/src/rust/mangastream/sources/luminousscans/res/source.json
+++ b/src/rust/mangastream/sources/luminousscans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.luminousscans",
 		"lang": "en",
 		"name": "Luminous Scans",
-		"version": 2,
+		"version": 3,
 		"url": "https://luminousscans.com"
 	},
 	"listings": [

--- a/src/rust/mangastream/sources/luminousscans/src/lib.rs
+++ b/src/rust/mangastream/sources/luminousscans/src/lib.rs
@@ -9,7 +9,7 @@ use mangastream_template::template::MangaStreamSource;
 fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
 		base_url: String::from("https://luminousscans.com"),
-		traverse_pathname: "home/series",
+		traverse_pathname: "series",
 		alt_pages: true,
 		..Default::default()
 	}


### PR DESCRIPTION
Luminous Scans updated their paths again, so quick fix

Checklist:
- [x] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
