### PR TITLE
fix(mangadex): parse dates in correct timezone

### DIFF
--- a/src/rust/multi.mangadex/res/source.json
+++ b/src/rust/multi.mangadex/res/source.json
@@ -4,7 +4,7 @@
 		"lang": "multi",
 		"name": "MangaDex",
 		"url": "https://mangadex.org",
-		"version": 4,
+		"version": 5,
 		"minAppVersion": "0.5"
 	},
 	"languages": [

--- a/src/rust/multi.mangadex/src/parser.rs
+++ b/src/rust/multi.mangadex/src/parser.rs
@@ -228,7 +228,7 @@ pub fn parse_chapter(chapter_object: ObjectRef) -> Result<Chapter> {
 
 	let date_updated = attributes
 		.get("publishAt")
-		.as_date("yyyy-MM-dd'T'HH:mm:ss+ss:ss", None, None)
+		.as_date("yyyy-MM-dd'T'HH:mm:ss+ss:ss", None, Some("UTC"))
 		.unwrap_or(-1.0);
 
 	// Fix for Skittyblock/aidoku-community-sources#25


### PR DESCRIPTION
MangaDex uses UTC timestamps, without this fix new chapters would not show up for hours because the timestamps were parsed as future times.

Checklist:
- [x] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
