### PR TITLE
Migrate jitterbit/get-changed-files to Ana06/get-changed-files

### DIFF
--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -13,7 +13,7 @@ jobs:
       -
         name: Get changed files
         id: files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.2.0
         with:
           format: json
       -

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,7 @@ jobs:
     -
       name: Get changed files
       id: files
-      uses: jitterbit/get-changed-files@v1
+      uses: Ana06/get-changed-files@v2.2.0
       with:
         format: json
     -


### PR DESCRIPTION
original action uses `node12` (deprecated soon) and uses `set-output` (also deprecated soon) with no signs of fixing: jitterbit/get-changed-files#55

moving to a fork which does fix it: https://github.com/Ana06/get-changed-files