### PR TITLE
fix(nepnep): remove more chapter prefixes and parse volumes

### DIFF
--- a/src/rust/en.nepnep/res/source.json
+++ b/src/rust/en.nepnep/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.nepnep",
 		"lang": "en",
 		"name": "MangaSee",
-		"version": 6,
+		"version": 7,
 		"urls": [
 			"https://mangasee123.com",
 			"https://manga4life.com"

--- a/src/rust/en.nepnep/src/parser.rs
+++ b/src/rust/en.nepnep/src/parser.rs
@@ -141,7 +141,7 @@ pub fn parse_chapter(manga_id: &str, chapter_object: ObjectRef) -> Result<Chapte
 			let title_chars = cleaned_title[0].chars().collect::<Vec<char>>();
 
 			if title_chars[0] == 'S' && title_chars[1].to_string().parse::<f64>().is_ok() {
-				volume = title_chars[1].to_string().parse::<f32>().unwrap();
+				volume = title_chars[1].to_string().parse::<f32>().unwrap_or(-1.0);
 				cleaned_title.remove(0);
 			}
 
@@ -156,7 +156,7 @@ pub fn parse_chapter(manga_id: &str, chapter_object: ObjectRef) -> Result<Chapte
 			&& (cleaned_title[0] == "Volume")
 			&& cleaned_title[1].parse::<f64>().is_ok()
 		{
-			volume = cleaned_title[1].parse::<f32>().unwrap();
+			volume = cleaned_title[1].parse::<f32>().unwrap_or(-1.0);
 			cleaned_title.remove(0);
 			cleaned_title.remove(0);
 		}

--- a/src/rust/en.nepnep/src/parser.rs
+++ b/src/rust/en.nepnep/src/parser.rs
@@ -5,6 +5,9 @@ use aidoku::{
 
 use super::helper::{chapter_image, chapter_url_encode};
 
+extern crate alloc;
+use alloc::string::ToString;
+
 // Parse manga with title and cover
 pub fn parse_basic_manga(manga_object: ObjectRef, cover_url: String) -> Result<Manga> {
 	let id = manga_object.get("i").as_string()?.read();
@@ -127,12 +130,44 @@ pub fn parse_chapter(manga_id: &str, chapter_object: ObjectRef) -> Result<Chapte
 		title.push_str(&chapter_image(&id, false));
 	}
 
+	let mut volume = -1.0;
+
 	let cleaned_title = {
 		let mut cleaned_title = title.split_whitespace().collect::<Vec<&str>>();
 
+		// Remove leading season text and set volume accordingly
+		// This is for titles like "S1 - Chapter 1"
+		if title.len() >= 2 {
+			let title_chars = cleaned_title[0].chars().collect::<Vec<char>>();
+
+			if title_chars[0] == 'S' && title_chars[1].to_string().parse::<f64>().is_ok() {
+				volume = title_chars[1].to_string().parse::<f32>().unwrap();
+				cleaned_title.remove(0);
+			}
+
+			// Remove leading symbols
+			if !cleaned_title.is_empty() && cleaned_title[0] == "-" {
+				cleaned_title.remove(0);
+			}
+		}
+
+		// Remove leading volume text and set volume accordingly
 		if cleaned_title.len() >= 2
-			&& (cleaned_title[0] == "Chapter" || cleaned_title[0] == "Episode")
+			&& (cleaned_title[0] == "Volume")
 			&& cleaned_title[1].parse::<f64>().is_ok()
+		{
+			volume = cleaned_title[1].parse::<f32>().unwrap();
+			cleaned_title.remove(0);
+			cleaned_title.remove(0);
+		}
+
+		// Remove leading chapter text
+		if cleaned_title.len() >= 2
+			&& (cleaned_title[0] == "Chapter"
+				|| cleaned_title[0] == "Episode"
+				|| cleaned_title[0] == "episode."
+				|| cleaned_title[0] == "No.")
+			|| cleaned_title[0] == "#" && cleaned_title[1].parse::<f64>().is_ok()
 		{
 			cleaned_title.remove(0);
 			cleaned_title.remove(0);
@@ -157,7 +192,7 @@ pub fn parse_chapter(manga_id: &str, chapter_object: ObjectRef) -> Result<Chapte
 	Ok(Chapter {
 		id: path,
 		title: cleaned_title,
-		volume: -1.0,
+		volume,
 		chapter,
 		date_updated,
 		scanlator: String::new(),


### PR DESCRIPTION
MangaSee uses special chapter prefixes as an homage to the series itself, I did not remove those, but I did remove all the generic chapter prefixes (that I've seen so far).

Checklist:
- [x] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
