### PR TITLE
fix(mangakatana): fix id parsing

### DIFF
--- a/src/rust/en.mangakatana/res/source.json
+++ b/src/rust/en.mangakatana/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.mangakatana",
 		"lang": "en",
 		"name": "MangaKatana",
-		"version": 1,
+		"version": 2,
 		"url": "https://mangakatana.com",
 		"nsfw": 1
 	}

--- a/src/rust/en.mangakatana/src/helper.rs
+++ b/src/rust/en.mangakatana/src/helper.rs
@@ -112,7 +112,7 @@ pub fn get_chapter_id(url: String) -> String {
 
 	let mut id = String::new();
 
-	let mut split_url = url.split('/').collect::<Vec<&str>>();
+	let mut split_url = url.split(['/', '.']).collect::<Vec<&str>>();
 	split_url.reverse();
 
 	if !split_url.is_empty() {

--- a/src/rust/en.mangakatana/src/helper.rs
+++ b/src/rust/en.mangakatana/src/helper.rs
@@ -95,6 +95,7 @@ pub fn get_manga_id(url: String) -> String {
 			// The first part that can be parsed as a u32 is the id.
 			if part.parse::<u32>().is_ok() {
 				id = String::from(part);
+				break;
 			}
 		}
 	}

--- a/src/rust/en.mangakatana/src/helper.rs
+++ b/src/rust/en.mangakatana/src/helper.rs
@@ -112,7 +112,7 @@ pub fn get_chapter_id(url: String) -> String {
 
 	let mut id = String::new();
 
-	let mut split_url = url.split(['/', '.']).collect::<Vec<&str>>();
+	let mut split_url = url.split('/').collect::<Vec<&str>>();
 	split_url.reverse();
 
 	if !split_url.is_empty() {
@@ -133,6 +133,7 @@ pub fn get_chapter_id(url: String) -> String {
 					.is_ok()
 			{
 				id = String::from(part);
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
I can't believe I did this :(

This should fix chapter and manga id's being messed up and broken chapter images.

Checklist:
- [x] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
