### PR TITLE
fix(mangastream): handle random chapter prefixes

### DIFF
--- a/src/rust/mangastream/sources/swatmanga/res/source.json
+++ b/src/rust/mangastream/sources/swatmanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "ar.swatmanga",
 		"lang": "ar",
 		"name": "SwatManga",
-		"version": 2,
+		"version": 3,
 		"url": "https://swatmanga.net"
 	},
 	"listings": [

--- a/src/rust/mangastream/sources/swatmanga/src/lib.rs
+++ b/src/rust/mangastream/sources/swatmanga/src/lib.rs
@@ -10,6 +10,7 @@ mod helper;
 
 fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
+		has_random_image_prefix: true,
 		listing: ["الرائج", "آخر", "جَديد"],
 		base_url: String::from("https://swatmanga.net"),
 		manga_details_title: ".infox h1",

--- a/src/rust/mangastream/sources/swatmanga/src/lib.rs
+++ b/src/rust/mangastream/sources/swatmanga/src/lib.rs
@@ -10,7 +10,7 @@ mod helper;
 
 fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
-		has_random_image_prefix: true,
+		has_random_chapter_prefix: true,
 		listing: ["الرائج", "آخر", "جَديد"],
 		base_url: String::from("https://swatmanga.net"),
 		manga_details_title: ".infox h1",

--- a/src/rust/mangastream/template/src/template.rs
+++ b/src/rust/mangastream/template/src/template.rs
@@ -13,6 +13,7 @@ use crate::helper::*;
 pub struct MangaStreamSource {
 	pub has_permanent_manga_url: bool,
 	pub has_permanent_chapter_url: bool,
+	pub has_random_image_prefix: bool,
 	pub is_nsfw: bool,
 	pub tagid_mapping: fn(String) -> String,
 	pub listing: [&'static str; 3],
@@ -61,6 +62,8 @@ impl Default for MangaStreamSource {
 		MangaStreamSource {
 			has_permanent_manga_url: false,
 			has_permanent_chapter_url: false,
+			// this is for urls like https://mangashit.cum/RANDOM_INT_PREFIX/chapter-1
+			has_random_image_prefix: false,
 			is_nsfw: false,
 			tagid_mapping: |str| str,
 			listing: ["Latest", "Popular", "New"],
@@ -360,7 +363,15 @@ impl MangaStreamSource {
 
 	//parse the maga chapter images list
 	pub fn parse_page_list(&self, id: String) -> Result<Vec<Page>> {
-		let url = format!("{}/{}", self.base_url, id);
+		let url = {
+			let mut url = format!("{}/{}", self.base_url, id);
+
+			if self.has_random_image_prefix {
+				url = format!("{}/{}/{}", self.base_url, 0, id);
+			}
+
+			url
+		};
 		let mut pages: Vec<Page> = Vec::new();
 		let html = Request::new(&url, HttpMethod::Get)
 			.header("Referer", &self.base_url)

--- a/src/rust/mangastream/template/src/template.rs
+++ b/src/rust/mangastream/template/src/template.rs
@@ -13,7 +13,7 @@ use crate::helper::*;
 pub struct MangaStreamSource {
 	pub has_permanent_manga_url: bool,
 	pub has_permanent_chapter_url: bool,
-	pub has_random_image_prefix: bool,
+	pub has_random_chapter_prefix: bool,
 	pub is_nsfw: bool,
 	pub tagid_mapping: fn(String) -> String,
 	pub listing: [&'static str; 3],
@@ -63,7 +63,7 @@ impl Default for MangaStreamSource {
 			has_permanent_manga_url: false,
 			has_permanent_chapter_url: false,
 			// this is for urls like https://mangashit.cum/RANDOM_INT_PREFIX/chapter-1
-			has_random_image_prefix: false,
+			has_random_chapter_prefix: false,
 			is_nsfw: false,
 			tagid_mapping: |str| str,
 			listing: ["Latest", "Popular", "New"],
@@ -366,7 +366,7 @@ impl MangaStreamSource {
 		let url = {
 			let mut url = format!("{}/{}", self.base_url, id);
 
-			if self.has_random_image_prefix {
+			if self.has_random_chapter_prefix {
 				url = format!("{}/{}/{}", self.base_url, 0, id);
 			}
 


### PR DESCRIPTION
Checklist:
- [x] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [ ] Set appropriate `nsfw` value
- [ ] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
