### PR TITLE
feat(mangadex): show multiple scanlators & uploader fallback

### DIFF
--- a/src/rust/multi.mangadex/res/source.json
+++ b/src/rust/multi.mangadex/res/source.json
@@ -4,7 +4,7 @@
 		"lang": "multi",
 		"name": "MangaDex",
 		"url": "https://mangadex.org",
-		"version": 6,
+		"version": 7,
 		"minAppVersion": "0.5"
 	},
 	"languages": [

--- a/src/rust/multi.mangadex/src/lib.rs
+++ b/src/rust/multi.mangadex/src/lib.rs
@@ -227,7 +227,7 @@ fn get_manga_listing(listing: Listing, page: i32) -> Result<MangaPageResult> {
 					if let Ok(relationships) = obj.get("relationships").as_array() {
 						for relationship in relationships {
 							if let Ok(relationship) = relationship.as_object()
-								   && let Ok(relation_type) = relationship.get("type").as_string() 
+								   && let Ok(relation_type) = relationship.get("type").as_string()
 								   && relation_type.read() == "manga"
 								   && let Ok(id) = relationship.get("id").as_string() {
 									let mut ret = String::from("&ids[]=");
@@ -294,6 +294,7 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 		&contentRating[]=erotica\
 		&contentRating[]=suggestive\
 		&contentRating[]=safe\
+		&includes[]=user\
 		&includes[]=scanlation_group";
 
 	if let Ok(languages) = defaults_get("languages").as_array() {

--- a/src/rust/multi.mangadex/src/parser.rs
+++ b/src/rust/multi.mangadex/src/parser.rs
@@ -228,7 +228,7 @@ pub fn parse_chapter(chapter_object: ObjectRef) -> Result<Chapter> {
 
 	let date_updated = attributes
 		.get("publishAt")
-		.as_date("yyyy-MM-dd'T'HH:mm:ss+ss:ss", None, Some("UTC"))
+		.as_date("yyyy-MM-dd'T'HH:mm:ss+ss:ss", Some("en-US"), Some("UTC"))
 		.unwrap_or(-1.0);
 
 	// Fix for Skittyblock/aidoku-community-sources#25

--- a/src/rust/multi.mangadex/src/parser.rs
+++ b/src/rust/multi.mangadex/src/parser.rs
@@ -260,20 +260,32 @@ pub fn parse_chapter(chapter_object: ObjectRef) -> Result<Chapter> {
 		title = String::from("Oneshot");
 	}
 
-	let mut scanlator = String::new();
+	let mut uploader = String::new();
+	let mut group: Vec<String> = Vec::new();
 
 	if let Ok(relationships) = chapter_object.get("relationships").as_array() {
 		for relationship in relationships {
 			if let Ok(relationship_object) = relationship.as_object()
 				&& let Ok(relation_type) = relationship_object.get("type").as_string()
 				&& let Ok(attribs) = relationship_object.get("attributes").as_object()
-				&& relation_type.read() == "scanlation_group"
 			{
-				scanlator = attribs.get("name").as_string().map(|v| v.read()).unwrap_or_default();
-				break;
+				if relation_type.clone().read() == "scanlation_group" {
+					group.push(attribs.get("name").as_string().map(|v| v.read()).unwrap_or_default());
+				} else if relation_type.clone().read() == "user" {
+					uploader = attribs.get("username").as_string().map(|v| v.read()).unwrap_or_default();
+				}
 			}
 		}
 	}
+
+	// If there's no group, use the uploader as the scanlator
+	let scanlator = {
+		if group.is_empty() {
+			uploader
+		} else {
+			group.join(", ")
+		}
+	};
 
 	let mut url = String::from("https://mangadex.org/chapter/");
 	url.push_str(&id);


### PR DESCRIPTION
Show all scanlator groups

Fallback to the uploader if there are no scanlator groups

Checklist:
- [x] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [ ] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
