### PR TITLE
Batoto: Fixed chapter list parsing

### DIFF
--- a/src/rust/multi.batoto/res/source.json
+++ b/src/rust/multi.batoto/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.batoto",
 		"lang": "multi",
 		"name": "Bato.to",
-		"version": 1,
+		"version": 2,
 		"urls": [
 			"https://bato.to",
 			"https://wto.to"


### PR DESCRIPTION
…sing.

Chapter string such as "Prolog" or "Notice" were producing an error while parsing leading to the function not outputting the list. Fixed the chapter number parsing at some places for string such as "V 1 C 1 [end]".

Checklist:
- [x] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [ ] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
