### PR TITLE
fix(luminousscans): remove has_permanent_manga_url

### DIFF
--- a/src/rust/mangastream/sources/luminousscans/res/source.json
+++ b/src/rust/mangastream/sources/luminousscans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.luminousscans",
 		"lang": "en",
 		"name": "Luminous Scans",
-		"version": 5,
+		"version": 6,
 		"url": "https://luminousscans.com"
 	},
 	"listings": [

--- a/src/rust/mangastream/sources/luminousscans/src/lib.rs
+++ b/src/rust/mangastream/sources/luminousscans/src/lib.rs
@@ -10,7 +10,6 @@ fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
 		base_url: String::from("https://luminousscans.com"),
 		traverse_pathname: "series",
-		has_permanent_manga_url: true,
 		alt_pages: true,
 		..Default::default()
 	}


### PR DESCRIPTION
Luminous has hardcoded a 10 digit prefix for all their manhwas, so it is no longer possible to remove it. All previous library entries will have to be migrated as the ID's have changed.

Checklist:
- [x] Updated source's version for individual source changes
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
