### PR TITLE
en.nepnep: hot updates page

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -298,9 +298,3 @@ Checklist:
 - [ ] Set appropriate `nsfw` value
 - [ ] Did not change `id` even if a source's name or language were changed
 - [ ] Tested the modifications by running it on the simulator or a test device 
-
-## Common Errors
-
-### `wasm32-unknown-unknown` target may not be installed
-
-Run `rustup target add wasm32-unknown-unknown --toolchain nightly`. Ref: https://github.com/rustwasm/wasm-bindgen/issues/929#issuecomment-427124646

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -298,3 +298,9 @@ Checklist:
 - [ ] Set appropriate `nsfw` value
 - [ ] Did not change `id` even if a source's name or language were changed
 - [ ] Tested the modifications by running it on the simulator or a test device 
+
+## Common Errors
+
+### `wasm32-unknown-unknown` target may not be installed
+
+Run `rustup target add wasm32-unknown-unknown --toolchain nightly`. Ref: https://github.com/rustwasm/wasm-bindgen/issues/929#issuecomment-427124646

--- a/src/rust/en.nepnep/res/source.json
+++ b/src/rust/en.nepnep/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.nepnep",
 		"lang": "en",
 		"name": "MangaSee",
-		"version": 8,
+		"version": 9,
 		"urls": [
 			"https://mangasee123.com",
 			"https://manga4life.com"
@@ -14,5 +14,8 @@
 		{
 			"type": "title"
 		}
+	],
+	"listings": [
+		{ "name": "Hot Updates" }
 	]
 }

--- a/src/rust/en.nepnep/src/lib.rs
+++ b/src/rust/en.nepnep/src/lib.rs
@@ -19,47 +19,39 @@ pub mod helper;
 mod parser;
 
 static mut DIRECTORY_RID: i32 = -1;
+static mut HOT_UPDATE_RID: i32 = -1;
+
 static mut CACHED_MANGA_ID: Option<String> = None;
 static mut CACHED_MANGA: Option<String> = None;
-static mut COVER_SERVER: Option<String> = None;
+const COVER_SERVER: &str = "https://temp.compsci88.com/cover/{{Result.i}}.jpg";
 
-// Cache full manga directory
-// Done to avoid repeated requests and speed up parsing
-pub fn initialize_directory() {
-	if let Ok(url_str) = defaults_get("sourceURL")
-		.expect("missing sourceURL")
-		.as_string()
-	{
-		let mut url = url_str.read();
-		url.push_str("/search/");
+pub fn init_page(path: &str, pattern: &str, cache: &mut i32) {
+	if let Ok(url_str) = defaults_get("sourceURL").expect("missing sourceURL").as_string() {
+        let mut url = url_str.read();
+        url.push_str(path);
 
 		let html = match Request::new(&url, HttpMethod::Get).html() {
-			Ok(html) => html,
-			Err(_) => return,
-		};
-		let node = html.select(".SearchResult > .SearchResultCover img");
-		unsafe {
-			COVER_SERVER = if node.has_attr("ng-src") {
-				Some(node.attr("ng-src").read())
-			} else {
-				Some(String::from(
-					"https://temp.compsci88.com/cover/{{Result.i}}.jpg",
-				))
-			};
-		}
+            Ok(html) => html,
+            Err(_) => return,
+        };
 
 		let result = html.outer_html().read();
-		let final_str = helper::string_between(&result, "vm.Directory = ", "];", 1);
+		let final_str = helper::string_between(&result, pattern, "];", 1);
 
+        
 		let mut directory_parsed = match parse(final_str.as_bytes()) {
 			Ok(parsed) => parsed,
 			Err(_) => return,
 		};
 		directory_parsed.1 = false;
-		unsafe {
-			DIRECTORY_RID = directory_parsed.0;
-		}
+        *cache = directory_parsed.0;
 	}
+}
+
+// Cache full manga directory
+// Done to avoid repeated requests and speed up parsing
+pub fn initialize_directory() {
+    init_page("/search/", "vm.Directory = ", unsafe { &mut DIRECTORY_RID })
 }
 
 // Cache manga page html
@@ -146,9 +138,7 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 
 	for i in offset..end {
 		let manga_obj = directory_arr.get(i).as_object()?;
-		manga.push(parser::parse_basic_manga(manga_obj, unsafe {
-			COVER_SERVER.clone().unwrap_or_default()
-		})?);
+		manga.push(parser::parse_basic_manga(manga_obj, String::from(COVER_SERVER))?);
 	}
 
 	Ok(MangaPageResult {
@@ -157,9 +147,39 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 	})
 }
 
+pub fn initialize_hot_update() {
+    init_page("/hot.php", "vm.HotUpdateJSON = ", unsafe { &mut HOT_UPDATE_RID })
+}
+
 #[get_manga_listing]
-fn get_manga_listing(_listing: Listing, _page: i32) -> Result<MangaPageResult> {
-	todo!()
+fn get_manga_listing(listing: Listing, page: i32) -> Result<MangaPageResult> {
+    let listing_name = listing.name.as_str();
+    match listing_name {
+        "Hot Updates" => {
+            if unsafe { HOT_UPDATE_RID } < 0 {
+                initialize_hot_update()
+            }
+        },
+        _ => { println!("Received unexpected listing: {}", listing_name); }
+    }
+	let directory_arr = unsafe { ValueRef::new(copy(HOT_UPDATE_RID)) }.as_array()?;
+
+	let offset = (page as usize - 1) * 20;
+	let mut manga: Vec<Manga> = Vec::with_capacity(20);
+
+	let end = if directory_arr.len() > offset + 20 {
+		offset + 20
+	} else {
+		directory_arr.len()
+	};
+	for i in offset..end {
+		let manga_obj = directory_arr.get(i).as_object()?;
+		manga.push(parser::parse_manga_listing(manga_obj)?);
+	}
+	Ok(MangaPageResult {
+		manga,
+		has_more: directory_arr.len() > end,
+	})
 }
 
 #[get_manga_details]
@@ -167,7 +187,10 @@ fn get_manga_details(id: String) -> Result<Manga> {
 	cache_manga_page(&id);
 	let html = unsafe { Node::new(CACHED_MANGA.clone().unwrap().as_bytes()) }?;
 
-	let mut url = defaults_get("sourceURL")?.as_string()?.read();
+	let mut url = defaults_get("sourceURL")
+		.expect("missing sourceURL")
+        .as_string()
+        ?.read();
 	url.push_str("/manga/");
 	url.push_str(&id);
 
@@ -198,7 +221,10 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 
 #[get_page_list]
 fn get_page_list(chapter_id: String, _manga_id: String) -> Result<Vec<Page>> {
-	let mut url = defaults_get("sourceURL")?.as_string()?.read();
+	let mut url = defaults_get("sourceURL")
+        .expect("missing sourceURL")
+        .as_string()
+        ?.read();
 	url.push_str("/read-online/");
 	url.push_str(&chapter_id);
 
@@ -318,4 +344,12 @@ fn handle_url(url: String) -> Result<DeepLink> {
 	Err(aidoku::error::AidokuError {
 		reason: aidoku::error::AidokuErrorKind::Unimplemented,
 	})
+}
+
+#[cfg(test)]
+mod tests {
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 5);
+    }
 }

--- a/src/rust/en.nepnep/src/lib.rs
+++ b/src/rust/en.nepnep/src/lib.rs
@@ -164,10 +164,7 @@ fn get_manga_listing(listing: Listing, page: i32) -> Result<MangaPageResult> {
 			}
 		}
 		_ => {
-			println!("Received unexpected listing: {}", listing_name);
-			return Err(aidoku::error::AidokuError {
-				reason: aidoku::error::AidokuErrorKind::Unimplemented,
-			});
+			panic!("Received unexpected listing: {}", listing_name);
 		}
 	}
 	let directory_arr = unsafe { ValueRef::new(copy(HOT_UPDATE_RID)) }.as_array()?;

--- a/src/rust/en.nepnep/src/lib.rs
+++ b/src/rust/en.nepnep/src/lib.rs
@@ -188,7 +188,7 @@ fn get_manga_details(id: String) -> Result<Manga> {
 	let html = unsafe { Node::new(CACHED_MANGA.clone().unwrap().as_bytes()) }?;
 
 	let mut url = defaults_get("sourceURL")
-		.expect("missing sourceURL")
+        .expect("missing sourceURL")
         .as_string()
         ?.read();
 	url.push_str("/manga/");
@@ -346,10 +346,3 @@ fn handle_url(url: String) -> Result<DeepLink> {
 	})
 }
 
-#[cfg(test)]
-mod tests {
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 5);
-    }
-}

--- a/src/rust/en.nepnep/src/lib.rs
+++ b/src/rust/en.nepnep/src/lib.rs
@@ -187,7 +187,7 @@ fn get_manga_details(id: String) -> Result<Manga> {
 	cache_manga_page(&id);
 	let html = unsafe { Node::new(CACHED_MANGA.clone().unwrap().as_bytes()) }?;
 
-	let mut url = defaults_get("sourceURL")
+    let mut url = defaults_get("sourceURL")
         .expect("missing sourceURL")
         .as_string()
         ?.read();
@@ -221,11 +221,11 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 
 #[get_page_list]
 fn get_page_list(chapter_id: String, _manga_id: String) -> Result<Vec<Page>> {
-	let mut url = defaults_get("sourceURL")
+    let mut url = defaults_get("sourceURL")
         .expect("missing sourceURL")
         .as_string()
         ?.read();
-	url.push_str("/read-online/");
+    url.push_str("/read-online/");
 	url.push_str(&chapter_id);
 
 	let result = Request::new(&url, HttpMethod::Get).string()?;

--- a/src/rust/en.nepnep/src/parser.rs
+++ b/src/rust/en.nepnep/src/parser.rs
@@ -16,33 +16,24 @@ pub fn parse_manga_listing(manga_object: ObjectRef) -> Result<Manga> {
 	let title = manga_object.get("SeriesName").as_string()?.read();
 	let cover = String::from(COVER_SERVER).replace("{{Result.i}}", &id);
 
-    let mut url = defaults_get("sourceURL")
-        .expect("missing sourceURL")
-        .as_string()
-        ?.read();
+	let mut url = defaults_get("sourceURL")?.as_string()?.read();
 	url.push_str("/manga/");
 	url.push_str(&id);
 
 	Ok(Manga {
 		id,
-		cover,
 		title,
-		author: String::new(),
-		artist: String::new(),
-		description: String::new(),
+		cover,
 		url,
-		categories: Vec::new(),
-		status: MangaStatus::Unknown,
-		nsfw: MangaContentRating::Safe,
-		viewer: MangaViewer::Default,
+		..Default::default()
 	})
 }
 
 // Parse manga with title and cover
-pub fn parse_basic_manga(manga_object: ObjectRef, cover_url: String) -> Result<Manga> {
+pub fn parse_basic_manga(manga_object: ObjectRef) -> Result<Manga> {
 	let id = manga_object.get("i").as_string()?.read();
 	let title = manga_object.get("s").as_string()?.read();
-	let cover = cover_url.replace("{{Result.i}}", &id);
+	let cover = String::from(COVER_SERVER).replace("{{Result.i}}", &id);
 
 	let mut url = defaults_get("sourceURL")?.as_string()?.read();
 	url.push_str("/manga/");

--- a/src/rust/en.nepnep/src/parser.rs
+++ b/src/rust/en.nepnep/src/parser.rs
@@ -16,7 +16,7 @@ pub fn parse_manga_listing(manga_object: ObjectRef) -> Result<Manga> {
 	let title = manga_object.get("SeriesName").as_string()?.read();
 	let cover = String::from(COVER_SERVER).replace("{{Result.i}}", &id);
 
-	let mut url = defaults_get("sourceURL")
+    let mut url = defaults_get("sourceURL")
         .expect("missing sourceURL")
         .as_string()
         ?.read();

--- a/src/rust/en.nepnep/src/parser.rs
+++ b/src/rust/en.nepnep/src/parser.rs
@@ -17,7 +17,7 @@ pub fn parse_manga_listing(manga_object: ObjectRef) -> Result<Manga> {
 	let cover = String::from(COVER_SERVER).replace("{{Result.i}}", &id);
 
 	let mut url = defaults_get("sourceURL")
-		.expect("missing sourceURL")
+        .expect("missing sourceURL")
         .as_string()
         ?.read();
 	url.push_str("/manga/");

--- a/src/rust/en.nepnep/src/parser.rs
+++ b/src/rust/en.nepnep/src/parser.rs
@@ -8,6 +8,36 @@ use super::helper::{chapter_image, chapter_url_encode};
 extern crate alloc;
 use alloc::string::ToString;
 
+const COVER_SERVER: &str = "https://temp.compsci88.com/cover/{{Result.i}}.jpg";
+
+// Parse manga with title and cover
+pub fn parse_manga_listing(manga_object: ObjectRef) -> Result<Manga> {
+	let id = manga_object.get("IndexName").as_string()?.read();
+	let title = manga_object.get("SeriesName").as_string()?.read();
+	let cover = String::from(COVER_SERVER).replace("{{Result.i}}", &id);
+
+	let mut url = defaults_get("sourceURL")
+		.expect("missing sourceURL")
+        .as_string()
+        ?.read();
+	url.push_str("/manga/");
+	url.push_str(&id);
+
+	Ok(Manga {
+		id,
+		cover,
+		title,
+		author: String::new(),
+		artist: String::new(),
+		description: String::new(),
+		url,
+		categories: Vec::new(),
+		status: MangaStatus::Unknown,
+		nsfw: MangaContentRating::Safe,
+		viewer: MangaViewer::Default,
+	})
+}
+
 // Parse manga with title and cover
 pub fn parse_basic_manga(manga_object: ObjectRef, cover_url: String) -> Result<Manga> {
 	let id = manga_object.get("i").as_string()?.read();


### PR DESCRIPTION
copied a lot of the code from what was already here such as using a static cache and refactored things along the way.

I couldn't find references to `.SearchResult > .SearchResultCover` in their website so I'd assumed it was removed

Checklist:
- [x] Updated source's version for individual source changes
- [x] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
