### PR TITLE
fix(mangastream): parse ints as u64 instead of u32

### DIFF
--- a/src/rust/mangastream/sources/asurascans/res/source.json
+++ b/src/rust/mangastream/sources/asurascans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.asurascans",
 		"lang": "multi",
 		"name": "Asura Scans",
-		"version": 4,
+		"version": 5,
 		"url": "https://www.asurascans.com"
 	},
 	"listings": [

--- a/src/rust/mangastream/sources/flamescans/res/source.json
+++ b/src/rust/mangastream/sources/flamescans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.flamescans",
 		"lang": "multi",
 		"name": "Flame Scans",
-		"version": 3,
+		"version": 4,
 		"url": "https://flamescans.org"
 	},
 	"listings": [

--- a/src/rust/mangastream/template/src/helper.rs
+++ b/src/rust/mangastream/template/src/helper.rs
@@ -312,7 +312,7 @@ pub fn get_permanet_url(original_url: String) -> String {
 
 	// check if the garbage is a 10 digit number to prevent removing the wrong part
 	// of the url the garbage should always be a 10 digit number
-	if garbage.parse::<u32>().is_ok() && garbage.len() == 10 {
+	if garbage.parse::<u64>().is_ok() && garbage.len() == 10 {
 		// remove the garbage from the url
 		// example https://luminousscans.com/series/1671729411-a-bad-person/
 		// will return https://luminousscans.com/series/a-bad-person


### PR DESCRIPTION
Garbage was parsed as a u32, which could not handle large numbers
- fix(mangastream): parse ints as u64 instead of u32
- chore(asurascans): bump version
- chore(flamescans): bump version

I only bumped the sources that rely on permanent urls

silly me 😌

Checklist:
- [x] Updated source's version for individual source changes
- [x] Tested the modifications by running it on the simulator or a test device 
