### PR TITLE
fix(asurascans): remove has_permanent_chapter_url

### DIFF
--- a/src/rust/mangastream/sources/asurascans/res/source.json
+++ b/src/rust/mangastream/sources/asurascans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.asurascans",
 		"lang": "multi",
 		"name": "Asura Scans",
-		"version": 5,
+		"version": 6,
 		"url": "https://www.asurascans.com"
 	},
 	"listings": [

--- a/src/rust/mangastream/sources/asurascans/src/lib.rs
+++ b/src/rust/mangastream/sources/asurascans/src/lib.rs
@@ -12,7 +12,6 @@ fn get_instance() -> MangaStreamSource {
 		tagid_mapping: get_tag_id,
 		base_url: get_base_url(),
 		has_permanent_manga_url: true,
-		has_permanent_chapter_url: true,
 		alt_pages: true,
 		last_page_text_2: "Sonraki",
 		chapter_date_format_2: "MMMM d, yyyy",


### PR DESCRIPTION
Unfortunately not all chapters on asura support permanent url's so some chapters break if this is enabled

This also means read history will be lost if asura rerolls the random int prefix (which they have been doing frequently) on the chapter url's as that will change the chapter id

- fix(asurascans): remove has_permanent_chapter_url
- chore(asurascans): bump version

Checklist:
- [x] Updated source's version for individual source changes
- [x] Tested the modifications by running it on the simulator or a test device 
