### PR TITLE
nepnep: sort feature and refactor a lot of things

### DIFF
--- a/src/rust/en.nepnep/Cargo.lock
+++ b/src/rust/en.nepnep/Cargo.lock
@@ -30,7 +30,7 @@ source = "git+https://github.com/Aidoku/aidoku-rs#5b39ffb250e905b6dd1145d94db1f5
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -38,6 +38,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "libc"
@@ -56,6 +62,8 @@ name = "nepnep-aidoku"
 version = "0.1.0"
 dependencies = [
  "aidoku",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -77,10 +85,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "serde"
+version = "1.0.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/en.nepnep/Cargo.toml
+++ b/src/rust/en.nepnep/Cargo.toml
@@ -17,3 +17,5 @@ lto = true
 
 [dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs" }
+serde = { version = "1.0.140", default-features = false, features = ["derive", "alloc"] }
+serde_json = { version = "1.0.82", default-features = false, features = ["alloc"] }

--- a/src/rust/en.nepnep/res/filters.json
+++ b/src/rust/en.nepnep/res/filters.json
@@ -1,0 +1,24 @@
+[
+    {
+        "type": "title"
+    },
+    {
+        "type": "sort",
+		"name": "Sort",
+		"canAscend": false,
+		"options": [
+			"A-Z",
+			"Z-A",
+			"Recently Released Chapter",
+			"Year Released - Newest",
+			"Year Released - Oldest",
+			"Most Popular (All Time)",
+			"Most Popular (Monthly)",
+			"Least Popular",
+		],
+		"default": {
+			"index": 0,
+			"ascending": false
+		}
+    }
+]

--- a/src/rust/en.nepnep/res/filters.json
+++ b/src/rust/en.nepnep/res/filters.json
@@ -14,7 +14,7 @@
 			"Year Released - Oldest",
 			"Most Popular (All Time)",
 			"Most Popular (Monthly)",
-			"Least Popular",
+			"Least Popular"
 		],
 		"default": {
 			"index": 0,

--- a/src/rust/en.nepnep/res/source.json
+++ b/src/rust/en.nepnep/res/source.json
@@ -3,18 +3,13 @@
 		"id": "en.nepnep",
 		"lang": "en",
 		"name": "MangaSee",
-		"version": 9,
+		"version": 10,
 		"urls": [
 			"https://mangasee123.com",
 			"https://manga4life.com"
 		],
 		"nsfw": 1
 	},
-	"filters": [
-		{
-			"type": "title"
-		}
-	],
 	"listings": [
 		{ "name": "Hot Updates" }
 	]

--- a/src/rust/en.nepnep/src/lib.rs
+++ b/src/rust/en.nepnep/src/lib.rs
@@ -35,26 +35,22 @@ pub fn init_cache(cache: &mut Nepnep) {
 		};
 
 		let result = html.outer_html().read();
-        let final_str = helper::string_between(&result, cache.start(), cache.end(), 1);
+		let final_str = helper::string_between(&result, cache.start(), cache.end(), 1);
 
-        match cache {
-            Nepnep::Directory { items } => {
-                match serde_json::from_str(final_str.as_str()) {
-                    Ok(dir) => *items = dir,
-                    Err(err) => {
-                        println!("Unable to serialize :{:?}", err);
-                    }
-                }
-            }
-            Nepnep::HotUpdate { items } => {
-                match serde_json::from_str(final_str.as_str()) {
-                    Ok(dir) => *items = dir,
-                    Err(err) => {
-                        println!("Unable to serialize :{:?}", err);
-                    }
-                }
-            }
-        }
+		match cache {
+			Nepnep::Directory { items } => match serde_json::from_str(final_str.as_str()) {
+				Ok(dir) => *items = dir,
+				Err(err) => {
+					println!("Unable to serialize :{:?}", err);
+				}
+			},
+			Nepnep::HotUpdate { items } => match serde_json::from_str(final_str.as_str()) {
+				Ok(dir) => *items = dir,
+				Err(err) => {
+					println!("Unable to serialize :{:?}", err);
+				}
+			},
+		}
 	}
 }
 
@@ -85,14 +81,14 @@ pub fn cache_manga_page(id: &str) {
 
 #[get_manga_list]
 fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
-    if unsafe { &CACHED_DIR }.len() == 0 {
-        init_cache(unsafe { &mut CACHED_DIR })
-    }
-    
-    let mut dir = match unsafe { CACHED_DIR.clone() } {
-        Nepnep::Directory { items } => items,
-        _ => panic!("Unexpected type")
-    };
+	if unsafe { &CACHED_DIR }.len() == 0 {
+		init_cache(unsafe { &mut CACHED_DIR })
+	}
+
+	let mut dir = match unsafe { CACHED_DIR.clone() } {
+		Nepnep::Directory { items } => items,
+		_ => panic!("Unexpected type"),
+	};
 
 	let offset = (page as usize - 1) * 20;
 
@@ -115,16 +111,19 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 						}
 					};
 
-                    // check both series name and alt titles
+					// check both series name and alt titles
 					if manga.title.to_lowercase().contains(&title)
-						|| manga.alt_titles.iter().any(|x| x.to_lowercase().contains(&title))
+						|| manga
+							.alt_titles
+							.iter()
+							.any(|x| x.to_lowercase().contains(&title))
 					{
 						i += 1;
-                        continue;
-					} 
-                    // no match, remove
-                    dir.remove(i);
-                    size -= 1;
+						continue;
+					}
+					// no match, remove
+					dir.remove(i);
+					size -= 1;
 				}
 			}
 			FilterType::Sort => {
@@ -140,44 +139,18 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 					continue;
 				}
 
-                match idx {
-                    1 => {
-                        dir.sort_by(|a, b| {
-                            b.title.cmp(&a.title)
-                        });
-                    }
-                    2 => {
-                        dir.sort_by(|a, b| {
-                            b.last_updated.cmp(&a.last_updated)
-                        })
-                    }
-                    3 => {
-                        dir.sort_by(|a, b| {
-                            b.year.cmp(&a.year)
-                        })
-                    }
-                    4 => {
-                        dir.sort_by(|a, b| {
-                            a.year.cmp(&b.year)
-                        })
-                    }
-                    5 => {
-                        dir.sort_by(|a, b| {
-                            b.views.cmp(&a.views)
-                        })
-                    }
-                    6 => {
-                        dir.sort_by(|a, b| {
-                            b.views_month.cmp(&a.views_month)
-                        })
-                    }
-                    7 => {
-                        dir.sort_by(|a, b| {
-                            a.views.cmp(&b.views)
-                        })
-                    }
-                    _ => panic!("Unreachable sort idx reached: {}", idx)
-                }
+				match idx {
+					1 => {
+						dir.sort_by(|a, b| b.title.cmp(&a.title));
+					}
+					2 => dir.sort_by(|a, b| b.last_updated.cmp(&a.last_updated)),
+					3 => dir.sort_by(|a, b| b.year.cmp(&a.year)),
+					4 => dir.sort_by(|a, b| a.year.cmp(&b.year)),
+					5 => dir.sort_by(|a, b| b.views.cmp(&a.views)),
+					6 => dir.sort_by(|a, b| b.views_month.cmp(&a.views_month)),
+					7 => dir.sort_by(|a, b| a.views.cmp(&b.views)),
+					_ => panic!("Unreachable sort idx reached: {}", idx),
+				}
 			}
 			_ => continue,
 		}
@@ -211,7 +184,7 @@ fn get_manga_listing(listing: Listing, page: i32) -> Result<MangaPageResult> {
 	match listing_name {
 		"Hot Updates" => {
 			if unsafe { &CACHED_HOT_UPDATES }.len() == 0 {
-                init_cache(unsafe { &mut CACHED_HOT_UPDATES })
+				init_cache(unsafe { &mut CACHED_HOT_UPDATES })
 			}
 		}
 		_ => {
@@ -219,10 +192,10 @@ fn get_manga_listing(listing: Listing, page: i32) -> Result<MangaPageResult> {
 		}
 	}
 
-    let dir = match unsafe { CACHED_HOT_UPDATES.clone() } {
-        Nepnep::HotUpdate { items } => items,
-        _ => panic!("Unexpected type")
-    };
+	let dir = match unsafe { CACHED_HOT_UPDATES.clone() } {
+		Nepnep::HotUpdate { items } => items,
+		_ => panic!("Unexpected type"),
+	};
 
 	let offset = (page as usize - 1) * 20;
 

--- a/src/rust/en.nepnep/src/lib.rs
+++ b/src/rust/en.nepnep/src/lib.rs
@@ -19,7 +19,7 @@ pub mod helper;
 mod parser;
 
 mod model;
-use model::{to_sort_option, Nepnep, Pattern, Size, SortOptions};
+use model::{Nepnep, Pattern, Size, SortOptions};
 
 pub fn init_cache(cache: &mut Nepnep) {
 	if let Ok(url_str) = defaults_get("sourceURL")
@@ -133,7 +133,7 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 				};
 
 				let idx = value.get("index").as_int().unwrap_or(0) as i32;
-				let opt = to_sort_option(idx);
+				let opt = SortOptions::from(idx);
 
 				match opt {
 					// Site by default sorts to A-Z

--- a/src/rust/en.nepnep/src/lib.rs
+++ b/src/rust/en.nepnep/src/lib.rs
@@ -1,16 +1,16 @@
 #![no_std]
 #![allow(clippy::mut_range_bound)]
+#![feature(try_blocks)]
 
 use aidoku::{
 	error::Result,
 	prelude::*,
 	std::{
-		copy,
 		defaults::defaults_get,
 		html::Node,
 		json::parse,
 		net::{HttpMethod, Request},
-		String, ValueRef, Vec,
+		String, Vec,
 	},
 	Chapter, DeepLink, Filter, FilterType, Listing, Manga, MangaPageResult, Page,
 };
@@ -18,19 +18,16 @@ use aidoku::{
 pub mod helper;
 mod parser;
 
-static mut DIRECTORY_RID: i32 = -1;
-static mut HOT_UPDATE_RID: i32 = -1;
+mod model;
+use model::{Nepnep, Pattern, Size};
 
-static mut CACHED_MANGA_ID: Option<String> = None;
-static mut CACHED_MANGA: Option<String> = None;
-
-pub fn init_page(path: &str, pattern: &str, cache: &mut i32) {
+pub fn init_cache(cache: &mut Nepnep) {
 	if let Ok(url_str) = defaults_get("sourceURL")
 		.expect("missing sourceURL")
 		.as_string()
 	{
 		let mut url = url_str.read();
-		url.push_str(path);
+		url.push_str(cache.path());
 
 		let html = match Request::new(&url, HttpMethod::Get).html() {
 			Ok(html) => html,
@@ -38,22 +35,34 @@ pub fn init_page(path: &str, pattern: &str, cache: &mut i32) {
 		};
 
 		let result = html.outer_html().read();
-		let final_str = helper::string_between(&result, pattern, "];", 1);
+        let final_str = helper::string_between(&result, cache.start(), cache.end(), 1);
 
-		let mut directory_parsed = match parse(final_str.as_bytes()) {
-			Ok(parsed) => parsed,
-			Err(_) => return,
-		};
-		directory_parsed.1 = false;
-		*cache = directory_parsed.0;
+        match cache {
+            Nepnep::Directory { items } => {
+                match serde_json::from_str(final_str.as_str()) {
+                    Ok(dir) => *items = dir,
+                    Err(err) => {
+                        println!("Unable to serialize :{:?}", err);
+                    }
+                }
+            }
+            Nepnep::HotUpdate { items } => {
+                match serde_json::from_str(final_str.as_str()) {
+                    Ok(dir) => *items = dir,
+                    Err(err) => {
+                        println!("Unable to serialize :{:?}", err);
+                    }
+                }
+            }
+        }
 	}
 }
 
-// Cache full manga directory
-// Done to avoid repeated requests and speed up parsing
-pub fn initialize_directory() {
-	init_page("/search/", "vm.Directory = ", unsafe { &mut DIRECTORY_RID })
-}
+static mut CACHED_MANGA_ID: Option<String> = None;
+static mut CACHED_MANGA: Option<String> = None;
+
+static mut CACHED_DIR: Nepnep = Nepnep::Directory { items: Vec::new() };
+static mut CACHED_HOT_UPDATES: Nepnep = Nepnep::HotUpdate { items: Vec::new() };
 
 // Cache manga page html
 pub fn cache_manga_page(id: &str) {
@@ -76,13 +85,16 @@ pub fn cache_manga_page(id: &str) {
 
 #[get_manga_list]
 fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
-	if unsafe { DIRECTORY_RID } < 0 {
-		initialize_directory();
-	}
-	let mut directory_arr = unsafe { ValueRef::new(copy(DIRECTORY_RID)) }.as_array()?;
+    if unsafe { &CACHED_DIR }.len() == 0 {
+        init_cache(unsafe { &mut CACHED_DIR })
+    }
+    
+    let mut dir = match unsafe { CACHED_DIR.clone() } {
+        Nepnep::Directory { items } => items,
+        _ => panic!("Unexpected type")
+    };
 
 	let offset = (page as usize - 1) * 20;
-	let mut manga: Vec<Manga> = Vec::with_capacity(20);
 
 	for filter in filters {
 		match filter.kind {
@@ -90,67 +102,106 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 				let title = filter.value.as_string()?.read().to_lowercase();
 
 				let mut i = 0;
-				let mut size = directory_arr.len();
+				let mut size = dir.len();
 				for _ in 0..size {
 					if i >= size || i >= offset + 20 {
 						break;
 					}
-					let manga_title = match directory_arr.get(i).as_object()?.get("s").as_string() {
-						Ok(title) => title.read().to_lowercase(),
-						Err(_) => String::new(),
-					};
-					// check title
-					if manga_title.contains(&title) {
-						i += 1;
-					} else {
-						// check alt titles
-						if let Ok(alt_titles) =
-							directory_arr.get(i).as_object()?.get("al").as_array()
-						{
-							if alt_titles.into_iter().any(|a| {
-								if let Ok(alt_title) = a.as_string() {
-									alt_title.read().to_lowercase().contains(&title)
-								} else {
-									false
-								}
-							}) {
-								i += 1;
-								continue;
-							}
+					let manga = match dir.get(i) {
+						Some(manga) => manga,
+						None => {
+							i += 1;
+							continue;
 						}
-						// no match, remove
-						directory_arr.remove(i);
-						size -= 1;
-					}
+					};
+
+                    // check both series name and alt titles
+					if manga.title.to_lowercase().contains(&title)
+						|| manga.alt_titles.iter().any(|x| x.to_lowercase().contains(&title))
+					{
+						i += 1;
+                        continue;
+					} 
+                    // no match, remove
+                    dir.remove(i);
+                    size -= 1;
 				}
 			}
 			FilterType::Sort => {
-				// TODO
+				let value = match filter.value.as_object() {
+					Ok(value) => value,
+					Err(_) => continue,
+				};
+
+				let idx = value.get("index").as_int().unwrap_or(0) as i32;
+
+				// Site by default sorts A-Z
+				if idx == 0 {
+					continue;
+				}
+
+                match idx {
+                    1 => {
+                        dir.sort_by(|a, b| {
+                            b.title.cmp(&a.title)
+                        });
+                    }
+                    2 => {
+                        dir.sort_by(|a, b| {
+                            b.last_updated.cmp(&a.last_updated)
+                        })
+                    }
+                    3 => {
+                        dir.sort_by(|a, b| {
+                            b.year.cmp(&a.year)
+                        })
+                    }
+                    4 => {
+                        dir.sort_by(|a, b| {
+                            a.year.cmp(&b.year)
+                        })
+                    }
+                    5 => {
+                        dir.sort_by(|a, b| {
+                            b.views.cmp(&a.views)
+                        })
+                    }
+                    6 => {
+                        dir.sort_by(|a, b| {
+                            b.views_month.cmp(&a.views_month)
+                        })
+                    }
+                    7 => {
+                        dir.sort_by(|a, b| {
+                            a.views.cmp(&b.views)
+                        })
+                    }
+                    _ => panic!("Unreachable sort idx reached: {}", idx)
+                }
 			}
 			_ => continue,
 		}
 	}
 
-	let end = if directory_arr.len() > offset + 20 {
+	let end = if dir.len() > offset + 20 {
 		offset + 20
 	} else {
-		directory_arr.len()
+		dir.len()
 	};
 
+	let mut manga: Vec<Manga> = Vec::with_capacity(20);
+
 	for i in offset..end {
-		let manga_obj = directory_arr.get(i).as_object()?;
-		manga.push(parser::parse_basic_manga(manga_obj)?);
+		let manga_obj = dir.get(i);
+		match manga_obj {
+			Some(obj) => manga.push(parser::parse_basic_manga(obj)?),
+			None => panic!("Couldn't find index: {}", i),
+		}
 	}
 
 	Ok(MangaPageResult {
 		manga,
-		has_more: directory_arr.len() > end,
-	})
-}
-
-pub fn initialize_hot_update() {
-	init_page("/hot.php", "vm.HotUpdateJSON = ", unsafe {
-		&mut HOT_UPDATE_RID
+		has_more: dir.len() > end,
 	})
 }
 
@@ -159,31 +210,39 @@ fn get_manga_listing(listing: Listing, page: i32) -> Result<MangaPageResult> {
 	let listing_name = listing.name.as_str();
 	match listing_name {
 		"Hot Updates" => {
-			if unsafe { HOT_UPDATE_RID } < 0 {
-				initialize_hot_update()
+			if unsafe { &CACHED_HOT_UPDATES }.len() == 0 {
+                init_cache(unsafe { &mut CACHED_HOT_UPDATES })
 			}
 		}
 		_ => {
 			panic!("Received unexpected listing: {}", listing_name);
 		}
 	}
-	let directory_arr = unsafe { ValueRef::new(copy(HOT_UPDATE_RID)) }.as_array()?;
+
+    let dir = match unsafe { CACHED_HOT_UPDATES.clone() } {
+        Nepnep::HotUpdate { items } => items,
+        _ => panic!("Unexpected type")
+    };
 
 	let offset = (page as usize - 1) * 20;
-	let mut manga: Vec<Manga> = Vec::with_capacity(20);
 
-	let end = if directory_arr.len() > offset + 20 {
+	let end = if dir.len() > offset + 20 {
 		offset + 20
 	} else {
-		directory_arr.len()
+		dir.len()
 	};
+
+	let mut manga: Vec<Manga> = Vec::with_capacity(20);
 	for i in offset..end {
-		let manga_obj = directory_arr.get(i).as_object()?;
-		manga.push(parser::parse_manga_listing(manga_obj)?);
+		let manga_obj = dir.get(i);
+		match manga_obj {
+			Some(obj) => manga.push(parser::parse_manga_listing(obj)?),
+			None => panic!("Couldn't find index: {}", i),
+		}
 	}
 	Ok(MangaPageResult {
 		manga,
-		has_more: directory_arr.len() > end,
+		has_more: dir.len() > end,
 	})
 }
 

--- a/src/rust/en.nepnep/src/model/mod.rs
+++ b/src/rust/en.nepnep/src/model/mod.rs
@@ -97,18 +97,17 @@ pub enum SortOptions {
 }
 
 impl From<i32> for SortOptions {
-    fn from(value: i32) -> Self {
-        match value {
-            0 => SortOptions::AZ,
-            1 => SortOptions::ZA,
-            2 => SortOptions::RecentlyReleasedChapter,
-            3 => SortOptions::YearReleasedNewest,
-            4 => SortOptions::YearReleasedOldest,
-            5 => SortOptions::MostPopularAllTime,
-            6 => SortOptions::MostPopularMonthly,
-            7 => SortOptions::LeastPopular,
-            _ => SortOptions::AZ,
-        }
-    }
+	fn from(value: i32) -> Self {
+		match value {
+			0 => SortOptions::AZ,
+			1 => SortOptions::ZA,
+			2 => SortOptions::RecentlyReleasedChapter,
+			3 => SortOptions::YearReleasedNewest,
+			4 => SortOptions::YearReleasedOldest,
+			5 => SortOptions::MostPopularAllTime,
+			6 => SortOptions::MostPopularMonthly,
+			7 => SortOptions::LeastPopular,
+			_ => SortOptions::AZ,
+		}
+	}
 }
-

--- a/src/rust/en.nepnep/src/model/mod.rs
+++ b/src/rust/en.nepnep/src/model/mod.rs
@@ -96,16 +96,19 @@ pub enum SortOptions {
 	LeastPopular,
 }
 
-pub fn to_sort_option(idx: i32) -> SortOptions {
-	match idx {
-		0 => SortOptions::AZ,
-		1 => SortOptions::ZA,
-		2 => SortOptions::RecentlyReleasedChapter,
-		3 => SortOptions::YearReleasedNewest,
-		4 => SortOptions::YearReleasedOldest,
-		5 => SortOptions::MostPopularAllTime,
-		6 => SortOptions::MostPopularMonthly,
-		7 => SortOptions::LeastPopular,
-		_ => panic!("Unexpected idx: {}", idx),
-	}
+impl From<i32> for SortOptions {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => SortOptions::AZ,
+            1 => SortOptions::ZA,
+            2 => SortOptions::RecentlyReleasedChapter,
+            3 => SortOptions::YearReleasedNewest,
+            4 => SortOptions::YearReleasedOldest,
+            5 => SortOptions::MostPopularAllTime,
+            6 => SortOptions::MostPopularMonthly,
+            7 => SortOptions::LeastPopular,
+            _ => SortOptions::AZ,
+        }
+    }
 }
+

--- a/src/rust/en.nepnep/src/model/mod.rs
+++ b/src/rust/en.nepnep/src/model/mod.rs
@@ -1,86 +1,86 @@
-use aidoku::std::{
-    Vec, String
-};
+use aidoku::std::Vec;
 use serde::Deserialize;
 
+extern crate alloc;
+use alloc::borrow::Cow;
+
 #[derive(Deserialize, Debug, Clone)]
-pub enum Nepnep {
-    Directory { items: Vec<Directory> },
-    HotUpdate { items: Vec<HotUpdate> }
+pub enum Nepnep<'a> {
+	Directory { items: Vec<Directory<'a>> },
+	HotUpdate { items: Vec<HotUpdate<'a>> },
 }
 
 pub trait Pattern {
-    fn start(&self) -> &str;
-    fn end(&self) -> &str;
-    fn path(&self) -> &str;
+	fn start(&self) -> &str;
+	fn end(&self) -> &str;
+	fn path(&self) -> &str;
 }
 
-impl Pattern for Nepnep {
-    fn start(&self) -> &str {
-        match self {
-            Nepnep::Directory { .. } => "vm.Directory =",
-            Nepnep::HotUpdate { .. } => "vm.HotUpdateJSON ="
-        }
-    }
+impl Pattern for Nepnep<'_> {
+	fn start(&self) -> &str {
+		match self {
+			Nepnep::Directory { .. } => "vm.Directory =",
+			Nepnep::HotUpdate { .. } => "vm.HotUpdateJSON =",
+		}
+	}
 
-    fn end(&self) -> &str {
-        "];"
-    }
+	fn end(&self) -> &str {
+		"];"
+	}
 
-    fn path(&self) -> &str {
-        match self {
-            Nepnep::Directory { .. } => "/search/",
-            Nepnep::HotUpdate { .. } => "/hot.php"
-        }
-    }
+	fn path(&self) -> &str {
+		match self {
+			Nepnep::Directory { .. } => "/search/",
+			Nepnep::HotUpdate { .. } => "/hot.php",
+		}
+	}
 }
 
 pub trait Size {
-    fn len(&self) -> usize;
+	fn len(&self) -> usize;
 }
 
-impl Size for Nepnep {
-    fn len(&self) -> usize {
-        match self {
-            Nepnep::Directory { items } => items.len(),
-            Nepnep::HotUpdate { items } => items.len(),
-        }
-    }
+impl Size for Nepnep<'_> {
+	fn len(&self) -> usize {
+		match self {
+			Nepnep::Directory { items } => items.len(),
+			Nepnep::HotUpdate { items } => items.len(),
+		}
+	}
 }
-
 
 #[derive(Default, Deserialize, Debug, Clone)]
 #[serde(default)]
-pub struct Directory {
+pub struct Directory<'a> {
 	#[serde(rename = "i")]
-	pub id: String,
+	pub id: Cow<'a, str>,
 
 	#[serde(rename = "s")]
-	pub title: String,
+	pub title: Cow<'a, str>,
 
-    // time in epoch
+	// time in epoch
 	#[serde(rename = "lt")]
-    pub last_updated: i32,
+	pub last_updated: i32,
 
 	#[serde(rename = "y")]
-    pub year: String,
+	pub year: Cow<'a, str>,
 
 	#[serde(rename = "v")]
-    pub views: String,
+	pub views: Cow<'a, str>,
 
 	#[serde(rename = "vm")]
-    pub views_month: String,
+	pub views_month: Cow<'a, str>,
 
 	#[serde(rename = "al")]
-	pub alt_titles: Vec<String>,
+	pub alt_titles: Vec<Cow<'a, str>>,
 }
 
 #[derive(Default, Deserialize, Debug, Clone)]
 #[serde(default)]
-pub struct HotUpdate {
+pub struct HotUpdate<'a> {
 	#[serde(rename = "IndexName")]
-	pub id: String,
+	pub id: Cow<'a, str>,
 
 	#[serde(rename = "SeriesName")]
-	pub title: String,
+	pub title: Cow<'a, str>,
 }

--- a/src/rust/en.nepnep/src/model/mod.rs
+++ b/src/rust/en.nepnep/src/model/mod.rs
@@ -1,0 +1,86 @@
+use aidoku::std::{
+    Vec, String
+};
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+pub enum Nepnep {
+    Directory { items: Vec<Directory> },
+    HotUpdate { items: Vec<HotUpdate> }
+}
+
+pub trait Pattern {
+    fn start(&self) -> &str;
+    fn end(&self) -> &str;
+    fn path(&self) -> &str;
+}
+
+impl Pattern for Nepnep {
+    fn start(&self) -> &str {
+        match self {
+            Nepnep::Directory { .. } => "vm.Directory =",
+            Nepnep::HotUpdate { .. } => "vm.HotUpdateJSON ="
+        }
+    }
+
+    fn end(&self) -> &str {
+        "];"
+    }
+
+    fn path(&self) -> &str {
+        match self {
+            Nepnep::Directory { .. } => "/search/",
+            Nepnep::HotUpdate { .. } => "/hot.php"
+        }
+    }
+}
+
+pub trait Size {
+    fn len(&self) -> usize;
+}
+
+impl Size for Nepnep {
+    fn len(&self) -> usize {
+        match self {
+            Nepnep::Directory { items } => items.len(),
+            Nepnep::HotUpdate { items } => items.len(),
+        }
+    }
+}
+
+
+#[derive(Default, Deserialize, Debug, Clone)]
+#[serde(default)]
+pub struct Directory {
+	#[serde(rename = "i")]
+	pub id: String,
+
+	#[serde(rename = "s")]
+	pub title: String,
+
+    // time in epoch
+	#[serde(rename = "lt")]
+    pub last_updated: i32,
+
+	#[serde(rename = "y")]
+    pub year: String,
+
+	#[serde(rename = "v")]
+    pub views: String,
+
+	#[serde(rename = "vm")]
+    pub views_month: String,
+
+	#[serde(rename = "al")]
+	pub alt_titles: Vec<String>,
+}
+
+#[derive(Default, Deserialize, Debug, Clone)]
+#[serde(default)]
+pub struct HotUpdate {
+	#[serde(rename = "IndexName")]
+	pub id: String,
+
+	#[serde(rename = "SeriesName")]
+	pub title: String,
+}

--- a/src/rust/en.nepnep/src/model/mod.rs
+++ b/src/rust/en.nepnep/src/model/mod.rs
@@ -84,3 +84,28 @@ pub struct HotUpdate<'a> {
 	#[serde(rename = "SeriesName")]
 	pub title: Cow<'a, str>,
 }
+
+pub enum SortOptions {
+	AZ,
+	ZA,
+	RecentlyReleasedChapter,
+	YearReleasedNewest,
+	YearReleasedOldest,
+	MostPopularAllTime,
+	MostPopularMonthly,
+	LeastPopular,
+}
+
+pub fn to_sort_option(idx: i32) -> SortOptions {
+	match idx {
+		0 => SortOptions::AZ,
+		1 => SortOptions::ZA,
+		2 => SortOptions::RecentlyReleasedChapter,
+		3 => SortOptions::YearReleasedNewest,
+		4 => SortOptions::YearReleasedOldest,
+		5 => SortOptions::MostPopularAllTime,
+		6 => SortOptions::MostPopularMonthly,
+		7 => SortOptions::LeastPopular,
+		_ => panic!("Unexpected idx: {}", idx),
+	}
+}

--- a/src/rust/en.nepnep/src/parser.rs
+++ b/src/rust/en.nepnep/src/parser.rs
@@ -3,6 +3,8 @@ use aidoku::{
 	std::Vec, Chapter, Manga, MangaContentRating, MangaStatus, MangaViewer,
 };
 
+use crate::model::{HotUpdate, Directory};
+
 use super::helper::{chapter_image, chapter_url_encode};
 
 extern crate alloc;
@@ -11,38 +13,36 @@ use alloc::string::ToString;
 const COVER_SERVER: &str = "https://temp.compsci88.com/cover/{{Result.i}}.jpg";
 
 // Parse manga with title and cover
-pub fn parse_manga_listing(manga_object: ObjectRef) -> Result<Manga> {
-	let id = manga_object.get("IndexName").as_string()?.read();
-	let title = manga_object.get("SeriesName").as_string()?.read();
-	let cover = String::from(COVER_SERVER).replace("{{Result.i}}", &id);
+pub fn parse_manga_listing(manga_object: &HotUpdate) -> Result<Manga> {
+	let id = &manga_object.id;
+	let title = &manga_object.title;
+	let cover = String::from(COVER_SERVER).replace("{{Result.i}}", id);
 
 	let mut url = defaults_get("sourceURL")?.as_string()?.read();
 	url.push_str("/manga/");
-	url.push_str(&id);
+	url.push_str(id);
 
 	Ok(Manga {
-		id,
-		title,
+		id: id.clone(),
+		title: title.clone(),
 		cover,
 		url,
 		..Default::default()
 	})
 }
 
-// Parse manga with title and cover
-pub fn parse_basic_manga(manga_object: ObjectRef) -> Result<Manga> {
-	let id = manga_object.get("i").as_string()?.read();
-	let title = manga_object.get("s").as_string()?.read();
-	let cover = String::from(COVER_SERVER).replace("{{Result.i}}", &id);
+pub fn parse_basic_manga(nepnep: &Directory) -> Result<Manga> {
+	let id = &nepnep.id;
+	let title = &nepnep.title;
+	let cover = String::from(COVER_SERVER).replace("{{Result.i}}", id);
 
 	let mut url = defaults_get("sourceURL")?.as_string()?.read();
 	url.push_str("/manga/");
-	url.push_str(&id);
-
+	url.push_str(id);
 	Ok(Manga {
-		id,
+		id: id.clone(),
+		title: title.clone(),
 		cover,
-		title,
 		url,
 		..Default::default()
 	})

--- a/src/rust/en.nepnep/src/parser.rs
+++ b/src/rust/en.nepnep/src/parser.rs
@@ -3,7 +3,7 @@ use aidoku::{
 	std::Vec, Chapter, Manga, MangaContentRating, MangaStatus, MangaViewer,
 };
 
-use crate::model::{HotUpdate, Directory};
+use crate::model::{Directory, HotUpdate};
 
 use super::helper::{chapter_image, chapter_url_encode};
 
@@ -23,8 +23,8 @@ pub fn parse_manga_listing(manga_object: &HotUpdate) -> Result<Manga> {
 	url.push_str(id);
 
 	Ok(Manga {
-		id: id.clone(),
-		title: title.clone(),
+		id: id.to_string(),
+		title: title.to_string(),
 		cover,
 		url,
 		..Default::default()
@@ -40,8 +40,8 @@ pub fn parse_basic_manga(nepnep: &Directory) -> Result<Manga> {
 	url.push_str("/manga/");
 	url.push_str(id);
 	Ok(Manga {
-		id: id.clone(),
-		title: title.clone(),
+		id: id.to_string(),
+		title: title.to_string(),
 		cover,
 		url,
 		..Default::default()


### PR DESCRIPTION
Had to do a decent amount of refactor so I could use `Vec` sort features. Couldn't use &str for deserialized struct values since serde requires ownership for string values with [escaped values](https://github.com/serde-rs/serde/issues/1413#issuecomment-494892266). I also couldn't use `Cow` since we don't have it in aidoku-rs

Checklist:
- [x] Updated source's version for individual source changes
- [x] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
