### PR TITLE
fix(asurascans): remove has_permanent_manga_url

### DIFF
--- a/src/rust/mangastream/sources/asurascans/res/source.json
+++ b/src/rust/mangastream/sources/asurascans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.asurascans",
 		"lang": "multi",
 		"name": "Asura Scans",
-		"version": 6,
+		"version": 7,
 		"url": "https://www.asurascans.com"
 	},
 	"listings": [

--- a/src/rust/mangastream/sources/asurascans/src/lib.rs
+++ b/src/rust/mangastream/sources/asurascans/src/lib.rs
@@ -11,7 +11,6 @@ fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
 		tagid_mapping: get_tag_id,
 		base_url: get_base_url(),
-		has_permanent_manga_url: true,
 		alt_pages: true,
 		last_page_text_2: "Sonraki",
 		chapter_date_format_2: "MMMM d, yyyy",


### PR DESCRIPTION
Asura is doing annoying stuff again 😕

Checklist:
- [x] Updated source's version for individual source changes
- [x] Tested the modifications by running it on the simulator or a test device 
