### PR TITLE
fix(`mangabz`): percent-encode search string

### DIFF
--- a/src/rust/zh.mangabz/Cargo.lock
+++ b/src/rust/zh.mangabz/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/rust/zh.mangabz/res/source.json
+++ b/src/rust/zh.mangabz/res/source.json
@@ -3,7 +3,7 @@
 		"id": "zh.mangabz",
 		"lang": "zh",
 		"name": "Māngabz",
-		"version": 1,
+		"version": 2,
 		"url": "https://mangabz.com/",
 		"nsfw": 1
 	}

--- a/src/rust/zh.mangabz/src/lib.rs
+++ b/src/rust/zh.mangabz/src/lib.rs
@@ -9,15 +9,15 @@ use aidoku::{
 };
 
 mod parser;
-use parser::{BASE_URL, USER_AGENT};
+use parser::{get_filtered_url, request_get, BASE_URL, USER_AGENT};
 
 extern crate alloc;
 use alloc::string::ToString;
 
 #[get_manga_list]
 fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
-	let url = parser::get_filtered_url(filters, page);
-	let html = parser::request_get(url).html()?;
+	let url = get_filtered_url(filters, page);
+	let html = request_get(url).html()?;
 
 	parser::get_manga_list(html)
 }
@@ -25,7 +25,7 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 #[get_manga_details]
 fn get_manga_details(id: String) -> Result<Manga> {
 	let url = format!("{}{}bz/", BASE_URL, id);
-	let html = parser::request_get(url).html()?;
+	let html = request_get(url).html()?;
 
 	parser::get_manga_details(html, id)
 }
@@ -33,7 +33,7 @@ fn get_manga_details(id: String) -> Result<Manga> {
 #[get_chapter_list]
 fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 	let url = format!("{}{}bz/", BASE_URL, id);
-	let html = parser::request_get(url).html()?;
+	let html = request_get(url).html()?;
 
 	parser::get_chapter_list(html)
 }

--- a/src/rust/zh.mangabz/src/parser.rs
+++ b/src/rust/zh.mangabz/src/parser.rs
@@ -1,6 +1,6 @@
 use aidoku::{
 	error::Result,
-	helpers::substring::Substring,
+	helpers::{substring::Substring, uri::QueryParameters},
 	prelude::format,
 	std::{html::Node, net::Request, String, Vec},
 	Chapter, Filter, FilterType, Manga, MangaPageResult, MangaStatus, Page,
@@ -15,21 +15,20 @@ const GENRE: [u8; 10] = [0, 31, 26, 1, 2, 25, 11, 17, 15, 34];
 const SORT: [u8; 2] = [10, 2];
 
 pub fn get_filtered_url(filters: Vec<Filter>, page: i32) -> String {
-	let mut url = String::from(BASE_URL);
-
 	let mut is_searching = false;
-	let mut search_str = String::new();
 
 	let mut genre = 0;
 	let mut status = 0;
 	let mut sort = 10;
+
+	let mut query = QueryParameters::new();
 
 	for filter in filters {
 		match filter.kind {
 			FilterType::Title => {
 				if let Ok(filter_value) = filter.value.as_string() {
 					is_searching = true;
-					search_str = filter_value.read();
+					query.push("title", Some(filter_value.read().as_str()));
 				}
 			}
 			FilterType::Select => {
@@ -52,12 +51,13 @@ pub fn get_filtered_url(filters: Vec<Filter>, page: i32) -> String {
 		}
 	}
 
+	let mut url = String::from(BASE_URL);
 	if is_searching {
-		url.push_str(format!("search?title={}&page={}", search_str, page).as_str());
+		query.push("page", Some(page.to_string().as_str()));
+		url.push_str(format!("search?{}", query).as_str());
 	} else {
 		url.push_str(format!("manga-list-{}-{}-{}-p{}/", genre, status, sort, page).as_str());
 	}
-
 	url
 }
 


### PR DESCRIPTION
This PR fixes the bug that the source is unable to search in Chinese.

## Checklist

- [x] Updated source's version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Premise

I must be an idiot 🫠
I forgot I was developing a “Chinese” source, and didn’t percent-encode the search string. It’s funny that the site supports searching in Pinyin, so I wasn’t aware of that, and didn’t search in Chinese when testing.
And I always use `QueryParameters` in other sources, wth was I thinking 🥲

## Changes

- Percent-encoded search string
- Updated source’s version

## Screenshots
| Before | After | Source Info |
| :-: | :-: | :-: |
| ![IMG_CE9E85667801-1](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/95d9e31a-11e5-4473-8b0b-95ff46ddd211) | ![Simulator Screenshot - iPhone 14 Pro - 2023-05-20 at 00 55 02](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/069d2ecf-d393-4a9d-837e-a1f65bed95d2) | ![Simulator Screenshot - iPhone 14 Pro - 2023-05-20 at 02 05 50](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/9d2f418e-7ec4-4dab-96b1-d43750d505df) |

## Notes

This fix was tested on simulator and TestFlight app.

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**