### PR TITLE
Fix reaperscans selectors

### DIFF
--- a/src/rust/en.reaperscans/res/source.json
+++ b/src/rust/en.reaperscans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.reaperscans",
 		"lang": "en",
 		"name": "Reaper Scans",
-		"version": 5,
+		"version": 6,
 		"url": "https://reaperscans.com",
 		"nsfw": 0
 	},

--- a/src/rust/en.reaperscans/src/request_helper.rs
+++ b/src/rust/en.reaperscans/src/request_helper.rs
@@ -13,9 +13,7 @@ pub fn create_search_request_object(
 	base_url: String,
 	search_query: String,
 ) -> Result<Node, AidokuError> {
-	let html = Request::new(base_url, HttpMethod::Get)
-		.html()
-		.expect("Failed to get html");
+	let html = Request::new(base_url, HttpMethod::Get).html()?;
 	let csrf_elem = html.select("meta[name=csrf-token]");
 	let csrf = csrf_elem.attr("content").read();
 


### PR DESCRIPTION
just reaper things

- Update selectors to not use classes
- Replace `expect` with `?`
- Bump version

Checklist:
- [x] Updated source's version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Tested the modifications by running it on the simulator or a test device 
