### PR TITLE
fix(manhuaren): fix source not loading

### DIFF
--- a/src/rust/zh.manhuaren/Cargo.lock
+++ b/src/rust/zh.manhuaren/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "manhuaren"
@@ -115,18 +115,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -150,9 +150,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "version_check"

--- a/src/rust/zh.manhuaren/res/source.json
+++ b/src/rust/zh.manhuaren/res/source.json
@@ -3,7 +3,7 @@
 		"id": "zh.manhuaren",
 		"lang": "zh",
 		"name": "漫画人",
-		"version": 1,
+		"version": 2,
 		"url": "https://www.manhuaren.com",
 		"nsfw": 1
 	}

--- a/src/rust/zh.manhuaren/src/helper.rs
+++ b/src/rust/zh.manhuaren/src/helper.rs
@@ -10,6 +10,8 @@ use aidoku::{
 };
 use md5::{Digest, Md5};
 
+use crate::{USER_AGENT, X_YQ_YQCI};
+
 const HEX_CHARS: [char; 16] = [
 	'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
 ];
@@ -76,7 +78,8 @@ pub fn generate_get_query(args: &mut Vec<(String, String)>) -> String {
 
 pub fn request<T: AsRef<str>>(url: T, method: HttpMethod) -> Result<String> {
 	Request::new(url, method)
-		.header("User-Agent", "okhttp/3.11.0")
+		.header("X-Yq-Yqci", X_YQ_YQCI)
+		.header("User-Agent", USER_AGENT)
 		.string()
 }
 

--- a/src/rust/zh.manhuaren/src/helper.rs
+++ b/src/rust/zh.manhuaren/src/helper.rs
@@ -76,10 +76,7 @@ pub fn generate_get_query(args: &mut Vec<(String, String)>) -> String {
 
 pub fn request<T: AsRef<str>>(url: T, method: HttpMethod) -> Result<String> {
 	Request::new(url, method)
-		.header(
-			"X-Yq-Yqci",
-			"{\"av\":\"\",\"cl\":\"\",\"cy\":\"\",\"di\":\"0\",\"le\":\"zh\",\"os\":0,\"pt\":\"\"}",
-		)
+		.header("User-Agent", "okhttp/3.11.0")
 		.string()
 }
 

--- a/src/rust/zh.manhuaren/src/helper.rs
+++ b/src/rust/zh.manhuaren/src/helper.rs
@@ -53,6 +53,8 @@ pub fn generate_gsn_hash(args: &mut Vec<(String, String)>) -> String {
 
 pub fn generate_get_query(args: &mut Vec<(String, String)>) -> String {
 	args.push((String::from("gak"), String::from("android_manhuaren2")));
+	args.push((String::from("gft"), String::from("json")));
+	args.push((String::from("gui"), String::from("1")));
 
 	let gsn = generate_gsn_hash(args);
 
@@ -74,7 +76,10 @@ pub fn generate_get_query(args: &mut Vec<(String, String)>) -> String {
 
 pub fn request<T: AsRef<str>>(url: T, method: HttpMethod) -> Result<String> {
 	Request::new(url, method)
-		.header("X-Yq-Yqci", "{\"le\": \"zh\"}")
+		.header(
+			"X-Yq-Yqci",
+			"{\"av\":\"\",\"cl\":\"\",\"cy\":\"\",\"di\":\"0\",\"le\":\"zh\",\"os\":0,\"pt\":\"\"}",
+		)
 		.string()
 }
 

--- a/src/rust/zh.manhuaren/src/lib.rs
+++ b/src/rust/zh.manhuaren/src/lib.rs
@@ -24,12 +24,7 @@ const API_URL: &str = "http://mangaapi.manhuaren.com";
 
 #[modify_image_request]
 fn modify_image_request(request: Request) {
-	request
-		.header(
-			"X-Yq-Yqci",
-			"{\"av\":\"\",\"cl\":\"\",\"cy\":\"\",\"di\":\"0\",\"le\":\"zh\",\"os\":0,\"pt\":\"\"}",
-		)
-		.header("User-Agent", "okhttp/3.11.0");
+	request.header("User-Agent", "okhttp/3.11.0");
 }
 
 #[get_manga_list]

--- a/src/rust/zh.manhuaren/src/lib.rs
+++ b/src/rust/zh.manhuaren/src/lib.rs
@@ -22,9 +22,14 @@ const FILTER_SORT: [i32; 3] = [0, 1, 2];
 
 const API_URL: &str = "http://mangaapi.manhuaren.com";
 
+const X_YQ_YQCI: &str = r#"{ "av": "5.1.7", "cy": "TW", "lut": "1688669750819", "nettype": 1, "os": 2, "di": "", "fcl": "appstore", "fult": "1688669750819", "cl": "appstore", "token": "", "ciso": "tw", "fut": "1688669750818", "le": "en-GB", "ps": "0", "ov": "16.5.1", "at": 2, "rn": "750x1334", "ln": "", "pt": "com.ilike2.manhuaren", "dm": "iPhone12,8" }"#;
+const USER_AGENT: &str = "manhuaren_speed/5.1.7 (iPhone; iOS 16.5.1; Scale/2.00)";
+
 #[modify_image_request]
 fn modify_image_request(request: Request) {
-	request.header("User-Agent", "okhttp/3.11.0");
+	request
+		.header("X-Yq-Yqci", X_YQ_YQCI)
+		.header("User-Agent", USER_AGENT);
 }
 
 #[get_manga_list]

--- a/src/rust/zh.manhuaren/src/lib.rs
+++ b/src/rust/zh.manhuaren/src/lib.rs
@@ -25,10 +25,11 @@ const API_URL: &str = "http://mangaapi.manhuaren.com";
 #[modify_image_request]
 fn modify_image_request(request: Request) {
 	request
-		.header("X-Yq-Yqci", "{\"le\": \"zh\"}")
-		.header("User-Agent", "okhttp/3.11.0")
-		.header("Referer", "http://www.dm5.com/dm5api/")
-		.header("clubReferer", "http://mangaapi.manhuaren.com/");
+		.header(
+			"X-Yq-Yqci",
+			"{\"av\":\"\",\"cl\":\"\",\"cy\":\"\",\"di\":\"0\",\"le\":\"zh\",\"os\":0,\"pt\":\"\"}",
+		)
+		.header("User-Agent", "okhttp/3.11.0");
 }
 
 #[get_manga_list]


### PR DESCRIPTION
This PR fixes the bug that the source `manhuaren` is not loading.

## Checklist

- [x] Updated source's version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Premise

Same issue as mentioned in [Tachiyomi](https://github.com/tachiyomiorg/tachiyomi-extensions/issues/16909).

## Changes

- Updated query parameters
- Updated request headers
- Changed source’s version

## Screenshots

| Before | After |
| :-: | :-: |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-07-04 at 10 17 13](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/ef539074-454d-4911-a8d0-23e7a72ab7d0) | ![Simulator Screenshot - iPhone 14 Pro - 2023-07-07 at 17 08 37](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/8a8f5ff2-73da-461e-aa1e-ca7716c26e67) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
