### PR TITLE
feat(mangastream): postid support

### DIFF
--- a/src/rust/mangastream/Cargo.lock
+++ b/src/rust/mangastream/Cargo.lock
@@ -19,10 +19,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aidoku"
 version = "0.2.0"
-source = "git+https://github.com/Aidoku/aidoku-rs/#004bddabade7b24c58cf925b08f90dd093b00c9d"
+source = "git+https://github.com/Aidoku/aidoku-rs#004bddabade7b24c58cf925b08f90dd093b00c9d"
 dependencies = [
+ "aidoku_helpers",
  "aidoku_imports",
  "aidoku_macros",
  "aidoku_proc_macros",
@@ -30,24 +42,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "aidoku_helpers"
+version = "0.1.0"
+source = "git+https://github.com/Aidoku/aidoku-rs#004bddabade7b24c58cf925b08f90dd093b00c9d"
+dependencies = [
+ "aidoku_imports",
+]
+
+[[package]]
 name = "aidoku_imports"
 version = "0.2.0"
-source = "git+https://github.com/Aidoku/aidoku-rs/#004bddabade7b24c58cf925b08f90dd093b00c9d"
+source = "git+https://github.com/Aidoku/aidoku-rs#004bddabade7b24c58cf925b08f90dd093b00c9d"
 
 [[package]]
 name = "aidoku_macros"
 version = "0.1.0"
-source = "git+https://github.com/Aidoku/aidoku-rs/#004bddabade7b24c58cf925b08f90dd093b00c9d"
+source = "git+https://github.com/Aidoku/aidoku-rs#004bddabade7b24c58cf925b08f90dd093b00c9d"
 
 [[package]]
 name = "aidoku_proc_macros"
 version = "0.2.0"
-source = "git+https://github.com/Aidoku/aidoku-rs/#004bddabade7b24c58cf925b08f90dd093b00c9d"
+source = "git+https://github.com/Aidoku/aidoku-rs#004bddabade7b24c58cf925b08f90dd093b00c9d"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anigliscans"
@@ -82,6 +108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "cosmicscans"
 version = "0.1.0"
 dependencies = [
@@ -112,6 +144,16 @@ version = "0.1.0"
 dependencies = [
  "aidoku",
  "mangastream_template",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -197,6 +239,7 @@ name = "mangastream_template"
 version = "0.1.0"
 dependencies = [
  "aidoku",
+ "hashbrown",
 ]
 
 [[package]]
@@ -262,6 +305,12 @@ dependencies = [
  "aidoku",
  "mangastream_template",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "ozulscans"
@@ -361,6 +410,12 @@ name = "unicode-ident"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "voidscans"

--- a/src/rust/mangastream/sources/asurascans/res/source.json
+++ b/src/rust/mangastream/sources/asurascans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.asurascans",
 		"lang": "multi",
 		"name": "Asura Scans",
-		"version": 9,
+		"version": 10,
 		"url": "https://asura.nacm.xyz"
 	},
 	"listings": [

--- a/src/rust/mangastream/sources/asurascans/src/lib.rs
+++ b/src/rust/mangastream/sources/asurascans/src/lib.rs
@@ -9,6 +9,7 @@ pub mod helper;
 use helper::{get_base_url, get_tag_id};
 fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
+		use_postids: true,
 		tagid_mapping: get_tag_id,
 		base_url: get_base_url(),
 		alt_pages: true,

--- a/src/rust/mangastream/sources/luminousscans/res/source.json
+++ b/src/rust/mangastream/sources/luminousscans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.luminousscans",
 		"lang": "en",
 		"name": "Luminous Scans",
-		"version": 6,
+		"version": 7,
 		"url": "https://luminousscans.com"
 	},
 	"listings": [

--- a/src/rust/mangastream/sources/luminousscans/src/lib.rs
+++ b/src/rust/mangastream/sources/luminousscans/src/lib.rs
@@ -8,6 +8,7 @@ use mangastream_template::template::MangaStreamSource;
 
 fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
+		use_postids: true,
 		base_url: String::from("https://luminousscans.com"),
 		traverse_pathname: "series",
 		alt_pages: true,

--- a/src/rust/mangastream/template/Cargo.toml
+++ b/src/rust/mangastream/template/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs/" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs", features = ["helpers"] }
+hashbrown = "0.14.0"


### PR DESCRIPTION
Closes #382

This should solve the issues mangastream sources face whenever the urls or identifiers change. Theoretically, with postids, migration should no longer be necessary now, and chapter history won't be randomly reset.

I tested this with most english mangastream sources, and all was working well, with only 1 or 2 sources that did not support my postids implementation. That's why I have it as an opt-in setting for now, in the future this could become the default behavior if the majority of mangastream sources support it.

yes, it is a bit janky, but it works

Checklist:
- [x] Updated source's version for individual source changes
- [x] Tested the modifications by running it on the simulator or a test device 