### PR TITLE
feat(mangastream): split postids between manga entries and chapters

### DIFF
--- a/src/rust/mangastream/sources/asurascans/res/source.json
+++ b/src/rust/mangastream/sources/asurascans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.asurascans",
 		"lang": "multi",
 		"name": "Asura Scans",
-		"version": 10,
+		"version": 11,
 		"url": "https://asura.nacm.xyz"
 	},
 	"listings": [

--- a/src/rust/mangastream/sources/asurascans/src/lib.rs
+++ b/src/rust/mangastream/sources/asurascans/src/lib.rs
@@ -9,7 +9,10 @@ pub mod helper;
 use helper::{get_base_url, get_tag_id};
 fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
-		use_postids: true,
+		use_manga_postids: true,
+		// asura has a 10 sec rate limit per request on their api endpoint
+		// making it extremely slow to use postids for chapters
+		use_chapter_postids: false,
 		tagid_mapping: get_tag_id,
 		base_url: get_base_url(),
 		alt_pages: true,

--- a/src/rust/mangastream/sources/luminousscans/res/source.json
+++ b/src/rust/mangastream/sources/luminousscans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.luminousscans",
 		"lang": "en",
 		"name": "Luminous Scans",
-		"version": 7,
+		"version": 8,
 		"url": "https://luminousscans.com"
 	},
 	"listings": [

--- a/src/rust/mangastream/sources/luminousscans/src/lib.rs
+++ b/src/rust/mangastream/sources/luminousscans/src/lib.rs
@@ -8,7 +8,8 @@ use mangastream_template::template::MangaStreamSource;
 
 fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
-		use_postids: true,
+		use_manga_postids: true,
+		use_chapter_postids: true,
 		base_url: String::from("https://luminousscans.com"),
 		traverse_pathname: "series",
 		alt_pages: true,

--- a/src/rust/mangastream/template/src/template.rs
+++ b/src/rust/mangastream/template/src/template.rs
@@ -14,7 +14,8 @@ pub struct MangaStreamSource {
 	/// Use static post ids instead of dynamic ids parsed from urls \
 	/// Cannot be used together with `has_permanent_manga_url` or
 	/// `has_permanent_chapter_url`
-	pub use_postids: bool,
+	pub use_manga_postids: bool,
+	pub use_chapter_postids: bool,
 	pub has_permanent_manga_url: bool,
 	pub has_permanent_chapter_url: bool,
 	pub has_random_chapter_prefix: bool,
@@ -65,7 +66,8 @@ pub struct MangaStreamSource {
 impl Default for MangaStreamSource {
 	fn default() -> Self {
 		MangaStreamSource {
-			use_postids: false,
+			use_manga_postids: false,
+			use_chapter_postids: false,
 			has_permanent_manga_url: false,
 			has_permanent_chapter_url: false,
 			// this is for urls like https://mangashit.cum/RANDOM_INT_PREFIX/chapter-1
@@ -204,7 +206,7 @@ impl MangaStreamSource {
 			let url: String;
 			let id: String;
 
-			if self.use_postids {
+			if self.use_manga_postids {
 				let original_url = manga_node.select("a").attr("href").read();
 				id = get_postid_from_manga_url(
 					original_url,
@@ -251,7 +253,7 @@ impl MangaStreamSource {
 
 	// parse manga details page
 	pub fn parse_manga_details(&self, id: String) -> Result<Manga> {
-		let url = if self.use_postids {
+		let url = if self.use_manga_postids {
 			format!("{}/{}/?p={}", self.base_url, self.traverse_pathname, id)
 		} else {
 			format!("{}/{}/{}", self.base_url, self.traverse_pathname, id)
@@ -331,14 +333,14 @@ impl MangaStreamSource {
 
 	// parse the chapters list present on manga details page
 	pub fn parse_chapter_list(&self, id: String) -> Result<Vec<Chapter>> {
-		let chapter_url_to_postid_mapping = if self.use_postids {
+		let chapter_url_to_postid_mapping = if self.use_chapter_postids {
 			generate_chapter_url_to_postid_mapping(id.clone(), &self.base_url)?
 		} else {
 			Default::default()
 		};
 
 		let url = {
-			if self.use_postids {
+			if self.use_chapter_postids {
 				format!("{}/{}/?p={}", self.base_url, self.traverse_pathname, id)
 			} else {
 				format!("{}/{}/{}", self.base_url, self.traverse_pathname, id)
@@ -372,7 +374,7 @@ impl MangaStreamSource {
 			let chapter_url: String;
 			let chapter_id: String;
 
-			if self.use_postids {
+			if self.use_chapter_postids {
 				let original_url = chapter_node.select(self.chapter_url).attr("href").read();
 				let id = chapter_url_to_postid_mapping
 					.get(&original_url)
@@ -414,7 +416,7 @@ impl MangaStreamSource {
 
 	//parse the manga chapter images list
 	pub fn parse_page_list(&self, id: String) -> Result<Vec<Page>> {
-		let url = if self.use_postids {
+		let url = if self.use_manga_postids {
 			format!("{}/?p={}", self.base_url, id)
 		} else if self.has_random_chapter_prefix {
 			format!("{}/{}/{}", self.base_url, 0, id)

--- a/src/rust/mangastream/template/src/template.rs
+++ b/src/rust/mangastream/template/src/template.rs
@@ -340,7 +340,8 @@ impl MangaStreamSource {
 		};
 
 		let url = {
-			if self.use_chapter_postids {
+			// yes this should be `use_manga_postids` and not `use_chapter_postids`
+			if self.use_manga_postids {
 				format!("{}/{}/?p={}", self.base_url, self.traverse_pathname, id)
 			} else {
 				format!("{}/{}/{}", self.base_url, self.traverse_pathname, id)
@@ -416,7 +417,7 @@ impl MangaStreamSource {
 
 	//parse the manga chapter images list
 	pub fn parse_page_list(&self, id: String) -> Result<Vec<Page>> {
-		let url = if self.use_manga_postids {
+		let url = if self.use_chapter_postids {
 			format!("{}/?p={}", self.base_url, id)
 		} else if self.has_random_chapter_prefix {
 			format!("{}/{}/{}", self.base_url, 0, id)


### PR DESCRIPTION
This makes it possible to use postids for manga entries and chapters separately.

I disabled postids for asura's chapters, since they have a very harsh 1 request per 10 sec rate limit on their api endpoint, which makes the extension extremely slow, and hangs migration on large libraries.

Downside is chapter history will be lost if asura changes chapter id's again, but that's better than the severe rate limit issues.

Checklist:
- [x] Updated source's version for individual source changes
- [x] Tested the modifications by running it on the simulator or a test device 
