### PR TITLE
Fix shinigami domain

### DIFF
--- a/src/rust/madara/sources/shinigami/res/source.json
+++ b/src/rust/madara/sources/shinigami/res/source.json
@@ -3,8 +3,8 @@
 		"id": "id.shinigami",
 		"lang": "id",
 		"name": "Shinigami",
-		"version": 3,
-		"url": "https://shinigami.id",
+		"version": 4,
+		"url": "https://shinigami.ae",
 		"nsfw": 0
 	},
 	"listings": [

--- a/src/rust/madara/sources/shinigami/src/lib.rs
+++ b/src/rust/madara/sources/shinigami/src/lib.rs
@@ -8,7 +8,7 @@ use madara_template::template;
 
 fn get_data() -> template::MadaraSiteData {
 	let data: template::MadaraSiteData = template::MadaraSiteData {
-		base_url: String::from("https://shinigami.id"),
+		base_url: String::from("https://shinigami.ae"),
 		source_path: String::from("series"),
 		alt_ajax: true,
 		..Default::default()


### PR DESCRIPTION
- Shinigami changed their domain
- Bump version

Closes #436

Checklist:
- [x] Updated source's version for individual source changes
- [x] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
