### PR TITLE
Fix chapter number for TuMangaOnline.

### DIFF
--- a/src/rust/es.tumangaonline/Cargo.lock
+++ b/src/rust/es.tumangaonline/Cargo.lock
@@ -59,18 +59,18 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -95,6 +95,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"

--- a/src/rust/es.tumangaonline/res/source.json
+++ b/src/rust/es.tumangaonline/res/source.json
@@ -3,7 +3,7 @@
 		"id": "es.tumangaonline",
 		"lang": "es",
 		"name": "TuMangaOnline",
-		"version": 2,
+		"version": 3,
 		"url": "https://lectortmo.com"
 	},
 	"listings": [

--- a/src/rust/es.tumangaonline/src/lib.rs
+++ b/src/rust/es.tumangaonline/src/lib.rs
@@ -316,9 +316,14 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 			let chapter_num = {
 				let num_text = element.select("a.btn-collapse").text().read();
 				let half = num_text.substring_after("Capítulo ").unwrap_or(&num_text);
-				half.substring_before(":")
-					.unwrap_or(half)
-					.parse::<f32>()
+				half.chars()
+					.filter(|a| (*a >= '0' && *a <= '9') || *a == ' ' || *a == '.')
+					.collect::<String>()
+					.split(' ')
+					.collect::<Vec<&str>>()
+					.into_iter()
+					.map(|a| a.parse::<f32>().unwrap_or(0.0))
+					.find(|a| *a > 0.0)
 					.unwrap_or(0.0)
 			};
 


### PR DESCRIPTION
- Fixes the issue with the wrong chapter number at TuMangaOnline.
- Update the dependencies of TuMangaOnline source.

Checklist:
- [x] Updated source's version for individual source changes
- [x] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 