### PR TITLE
Fix 1stkissmanga get_chapter_list

### DIFF
--- a/src/rust/madara/sources/firstkissmanga/Cargo.toml
+++ b/src/rust/madara/sources/firstkissmanga/Cargo.toml
@@ -8,5 +8,6 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-aidoku = { git = "https://github.com/Aidoku/aidoku-rs/" }
+aidoku = { git = "https://github.com/Aidoku/aidoku-rs/", features = ["helpers"] }
+base64 = { version = "0.21.4", default-features = false, features = ["alloc"] }
 madara_template = { path = "../../template" }

--- a/src/rust/madara/sources/firstkissmanga/res/source.json
+++ b/src/rust/madara/sources/firstkissmanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.firstkissmanga",
 		"lang": "en",
 		"name": "1ST KISS MANGA",
-		"version": 2,
+		"version": 3,
 		"url": "https://1st-kissmanga.net",
 		"nsfw": 1
 	},

--- a/src/rust/madara/sources/firstkissmanga/src/lib.rs
+++ b/src/rust/madara/sources/firstkissmanga/src/lib.rs
@@ -1,14 +1,19 @@
 #![no_std]
 use aidoku::{
-	error::Result, prelude::*, std::net::Request, std::String, std::Vec, Chapter, DeepLink, Filter,
-	Listing, Manga, MangaPageResult, Page,
+	error::Result, prelude::*, std::net::Request, std::net::HttpMethod, std::String, std::Vec,
+	Chapter, DeepLink, Filter, Listing, Manga, MangaPageResult, Page,
+	helpers::substring::Substring
 };
 
 use madara_template::template;
 
+extern crate base64;
+use base64::{Engine as _, engine::general_purpose};
+
 fn get_data() -> template::MadaraSiteData {
 	let data: template::MadaraSiteData = template::MadaraSiteData {
 		base_url: String::from("https://1st-kissmanga.net"),
+		get_manga_id: get_int_manga_id,
 		alt_ajax: true,
 		..Default::default()
 	};
@@ -48,4 +53,22 @@ pub fn handle_url(url: String) -> Result<DeepLink> {
 #[modify_image_request]
 fn modify_image_request(request: Request) {
 	template::modify_image_request(get_data().base_url, request)
+}
+
+fn get_int_manga_id(manga_id: String, base_url: String, path: String) -> String {
+	let url = base_url + "/" + path.as_str() + "/" + manga_id.as_str();
+	if let Ok(html) = Request::new(url.as_str(), HttpMethod::Get).html() {
+		// For this web page, the script is encoded in base64
+		let id_html_encoded = html.select("script#wp-manga-js-extra").attr("src").read();
+		let id_html_base64 = id_html_encoded
+			.substring_after("data:text/javascript;base64,").unwrap_or_default();
+		let id_html_decoded = general_purpose::STANDARD.decode(id_html_base64).unwrap();
+		let id_html = String::from_utf8(id_html_decoded).unwrap_or_default();
+
+		let id = &id_html[id_html.find("manga_id").expect("Could not find manga_id") + 11
+			..id_html.find("\"}").expect("Could not find end of manga_id")];
+		String::from(id)
+	} else {
+		String::new()
+	}
 }


### PR DESCRIPTION
Fix:
- Added base64 decode for `<script type="text/javascript" id="wp-manga-js-extra">`

Checklist:
- [x] Updated source's version for individual source changes
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
