### PR TITLE
Fix comick url (from .fun to .app)

### DIFF
--- a/src/rust/multi.comick/res/source.json
+++ b/src/rust/multi.comick/res/source.json
@@ -3,8 +3,8 @@
 		"id": "multi.comick",
 		"lang": "multi",
 		"name": "ComicK",
-		"version": 5,
-		"url": "https://comick.fun",
+		"version": 6,
+		"url": "https://comick.app",
 		"nsfw": 1
 	},
 	"languages": [


### PR DESCRIPTION
Updated comick URL in source.json from comick.fun to comick.app

Every other instance is correct, just not the one in source.json 



Checklist:
- [x] Updated source's version for individual source changes
- [ ] ~~Updated all sources' versions for template changes~~ **not applicable**
- [ ] ~~Set appropriate `nsfw` value~~ **not applicable**
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
