### PR TITLE
fix(copymanga): chapters sorted incorrectly

### DIFF
--- a/src/rust/zh.copymanga/Cargo.lock
+++ b/src/rust/zh.copymanga/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -154,15 +154,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -189,21 +189,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 
 [[package]]
 name = "version_check"

--- a/src/rust/zh.copymanga/res/source.json
+++ b/src/rust/zh.copymanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "zh.copymanga",
 		"lang": "zh",
 		"name": "拷貝漫畫",
-		"version": 1,
+		"version": 2,
 		"url": "https://copymanga.site",
 		"urls": [
 			"https://copymanga.site",

--- a/src/rust/zh.copymanga/src/lib.rs
+++ b/src/rust/zh.copymanga/src/lib.rs
@@ -7,7 +7,9 @@ mod url;
 use aidoku::{
 	error::Result,
 	helpers::substring::Substring,
-	prelude::{get_chapter_list, get_manga_details, get_manga_list, get_page_list, handle_url},
+	prelude::{
+		format, get_chapter_list, get_manga_details, get_manga_list, get_page_list, handle_url,
+	},
 	std::{String, Vec},
 	Chapter, DeepLink, Filter, Manga, MangaPageResult, MangaStatus, Page,
 };
@@ -90,9 +92,17 @@ fn get_chapter_list(manga_id: String) -> Result<Vec<Chapter>> {
 		.get("groups")
 		.as_object()?
 		.values();
+	let group_values_len = group_values.len();
 	let groups = group_values
 		.map(|group_value| {
 			let group_obj = group_value.as_object()?;
+
+			let title_prefix = if group_values_len > 1 {
+				let group_name = group_obj.get_as_string("name")?;
+				format!("{}：", group_name)
+			} else {
+				String::new()
+			};
 
 			group_obj
 				.get("chapters")
@@ -102,7 +112,8 @@ fn get_chapter_list(manga_id: String) -> Result<Vec<Chapter>> {
 
 					let chapter_id = chapter_obj.get_as_string("id")?;
 
-					let title = chapter_obj.get_as_string("name")?;
+					let chapter_name = chapter_obj.get_as_string("name")?;
+					let title = format!("{}{}", title_prefix, chapter_name);
 
 					let timestamp = chapter_id.get_timestamp();
 


### PR DESCRIPTION
This PR fixes the bug that chapters are sorted incorrectly.

## Checklist

- [x] Updated source's version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Premise

Chapters in the same group are already sorted in the JSON file; but the current sorting method (sort by date updated) will mess up the correct order.

## Changes

- Updated dependencies in `Cargo.lock`
- Prevented chapters in the same group from being sorted
- Prefixed group name to chapter title
- Bumped version

## Screenshots

| Before | After |
| :-: | :-: |
| ![chapters_before](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/571adea4-72a3-4d32-b8c6-43e334b88b90) | ![chapters_after](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/4c1aaeff-3886-424e-92b8-2066641aac8e) |
| ![version_before](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/f64ecc45-2b9a-4bbe-8fbf-0fdea0d6ed2b) | ![version_after](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/e13c349d-88e5-48d9-83bc-7a4b43954c3d) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
