### PR TITLE
fix(copymanga): manga list not loading properly

### DIFF
--- a/src/rust/zh.copymanga/Cargo.lock
+++ b/src/rust/zh.copymanga/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "proc-macro2"
@@ -201,9 +201,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "uuid"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 
 [[package]]
 name = "version_check"

--- a/src/rust/zh.copymanga/res/source.json
+++ b/src/rust/zh.copymanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "zh.copymanga",
 		"lang": "zh",
 		"name": "拷貝漫畫",
-		"version": 2,
+		"version": 3,
 		"url": "https://copymanga.site",
 		"urls": [
 			"https://copymanga.site",

--- a/src/rust/zh.copymanga/src/parser.rs
+++ b/src/rust/zh.copymanga/src/parser.rs
@@ -14,22 +14,23 @@ pub trait MangaListResponse {
 
 impl MangaListResponse for Node {
 	fn get_page_result(self) -> Result<MangaPageResult> {
-		let manga = self
-			.get_attr("div.exemptComic-box", "list")
-			.split('"')
-			.enumerate()
-			.map(|(index, str)| {
-				if index % 2 == 0 {
-					str.replace('\'', "\"")
-				} else {
-					str.to_string()
-				}
-			})
-			.collect::<Vec<_>>()
-			.join("\"")
-			.json()?
-			.as_array()?
-			.get_manga_list()?;
+		let manga =
+			self.get_attr("div.exemptComic-box", "list")
+				.replace(r"\xa0", " ")
+				.split('"')
+				.enumerate()
+				.map(|(index, str)| {
+					if index % 2 == 0 {
+						str.replace('\'', "\"")
+					} else {
+						str.to_string()
+					}
+				})
+				.collect::<Vec<_>>()
+				.join("\"")
+				.json()?
+				.as_array()?
+				.get_manga_list()?;
 
 		let has_more = !self.select("li.page-all-item").last().has_class("active");
 


### PR DESCRIPTION
This PR fixes the bug that manga list is not loading properly.

## Checklist

- [x] Updated source's version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Premise

Function `aidoku::std::json::parse` could not parse a string contains `\xa0`.

## Changes

- Replaced `\xa0` with a space
- Updated source’s version

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
