### PR TITLE
fix(blogtruyen): pagination not working in filtered list

### DIFF
--- a/src/rust/vi.blogtruyen/res/source.json
+++ b/src/rust/vi.blogtruyen/res/source.json
@@ -3,7 +3,7 @@
 		"id": "vi.blogtruyen",
 		"lang": "vi",
 		"name": "BlogTruyen",
-		"version": 2,
+		"version": 3,
 		"url": "https://blogtruyenmoi.com",
 		"urls": [
 			"https://blogtruyenmoi.com",

--- a/src/rust/vi.blogtruyen/src/lib.rs
+++ b/src/rust/vi.blogtruyen/src/lib.rs
@@ -116,7 +116,7 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 		}
 		Ok(MangaPageResult {
 			manga: manga_arr,
-			has_more: html.select("a:contains([cuối])").array().len() > 0,
+			has_more: html.select("a[title=\"Trang cuối\"]").array().len() > 0,
 		})
 	} else {
 		let html =


### PR DESCRIPTION
This PR fixes an issue where an invalid query selector (`a:contains([cuối])`) was used for the detection of `has_more`, resulting in only fetching the first page of results.
=> Should use the same selector as when no filters are provided.

https://github.com/Skittyblock/aidoku-community-sources/blob/6ac77a63245521809566382d391e08dc8c68ea2a/src/rust/vi.blogtruyen/src/lib.rs#L177-L180

Checklist:
- [x] Updated source's version for individual source changes
- [x] Tested the modifications by running it on the simulator or a test device 
