### PR TITLE
Update to the new Url for ComicK

### DIFF
--- a/src/rust/multi.comick/res/source.json
+++ b/src/rust/multi.comick/res/source.json
@@ -3,8 +3,8 @@
 		"id": "multi.comick",
 		"lang": "multi",
 		"name": "ComicK",
-		"version": 6,
-		"url": "https://comick.app",
+		"version": 7,
+		"url": "https://comick.cc",
 		"nsfw": 1
 	},
 	"languages": [

--- a/src/rust/multi.comick/src/lib.rs
+++ b/src/rust/multi.comick/src/lib.rs
@@ -11,7 +11,7 @@ pub mod helper;
 pub mod parser;
 
 const BASE_URL: &str = "https://comick.cc";
-const API_URL: &str = "https://api.comick.fun";
+const API_URL: &str = "https://api.comick.cc";
 
 #[get_manga_list]
 fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {

--- a/src/rust/multi.comick/src/lib.rs
+++ b/src/rust/multi.comick/src/lib.rs
@@ -10,8 +10,8 @@ use aidoku::{
 pub mod helper;
 pub mod parser;
 
-const BASE_URL: &str = "https://comick.app";
-const API_URL: &str = "https://api.comick.app";
+const BASE_URL: &str = "https://comick.cc";
+const API_URL: &str = "https://api.comick.fun";
 
 #[get_manga_list]
 fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {


### PR DESCRIPTION
Checklist:
- [x] Updated source's version for individual source changes
- [x] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [ ] Tested the modifications by running it on the simulator or a test device 

ComicK moved from their `.app` domain to https://comick.cc (and https://api.comick.fun for the API).

Was unable to test the source, as the aidoku-cli just segfaults on my machine.
Should not cause any issues tho, as this is purely a url change in the strings.

Fixes #533