### PR TITLE
fix(boylove): shuffled image pieces

### DIFF
--- a/src/rust/zh.boylove/Cargo.lock
+++ b/src/rust/zh.boylove/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "boylove"
@@ -54,6 +54,7 @@ version = "0.1.0"
 dependencies = [
  "aidoku",
  "base64",
+ "regex",
 ]
 
 [[package]]
@@ -67,27 +68,52 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "syn"
@@ -102,6 +128,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/src/rust/zh.boylove/Cargo.toml
+++ b/src/rust/zh.boylove/Cargo.toml
@@ -18,3 +18,4 @@ lto = true
 [dependencies]
 aidoku = { git = "https://github.com/Aidoku/aidoku-rs", features = ["helpers"] }
 base64 = { version = "0.21.2", default-features = false, features = ["alloc"] }
+regex = { version = "1.10.2", default-features = false, features = ["unicode"] }

--- a/src/rust/zh.boylove/res/source.json
+++ b/src/rust/zh.boylove/res/source.json
@@ -3,7 +3,7 @@
 		"id": "zh.boylove",
 		"lang": "zh",
 		"name": "香香腐宅",
-		"version": 4,
+		"version": 5,
 		"url": "https://boylove.cc",
 		"urls": [
 			"https://boylove.cc",

--- a/src/rust/zh.boylove/src/lib.rs
+++ b/src/rust/zh.boylove/src/lib.rs
@@ -16,6 +16,7 @@ use aidoku::{
 };
 use alloc::string::ToString;
 use base64::{engine::general_purpose, Engine};
+use regex::Regex;
 use url::{Url, CHAPTER_PATH, DOMAIN, MANGA_PATH, USER_AGENT};
 
 #[initialize]
@@ -196,12 +197,24 @@ fn get_page_list(_manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
 	let mut pages = Vec::<Page>::new();
 	let page_nodes = chapter_html.select("img.lazy[id]");
 	for (page_index, page_value) in page_nodes.array().enumerate() {
-		let page_path = page_value
+		let mut page_path = page_value
 			.as_node()?
 			.attr("data-original")
 			.read()
 			.trim()
 			.to_string();
+		if let Some(caps) = Regex::new(
+			r"(?<chapter>\/bookimages\/\d{8}\/\d+)-(?<page_id>[a-z0-9]{32,})\.(?<file_extension>[^\?]+)",
+		)
+		.expect("Invalid regular expression")
+		.captures(&page_path)
+		{
+			let chapter = &caps["chapter"];
+			let page_id = &caps["page_id"][..32];
+			let file_extension = &caps["file_extension"];
+			page_path = format!("{chapter}-{page_id}.{file_extension}");
+		};
+
 		let page_url = Url::Abs(page_path).to_string();
 
 		pages.push(Page {

--- a/src/rust/zh.boylove/src/lib.rs
+++ b/src/rust/zh.boylove/src/lib.rs
@@ -204,7 +204,7 @@ fn get_page_list(_manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
 			.trim()
 			.to_string();
 		if let Some(caps) = Regex::new(
-			r"(?<chapter>\/bookimages\/\d{8}\/\d+)-(?<page_id>[a-z0-9]{32,})\.(?<file_extension>[^\?]+)",
+			r"(?<chapter>.+[^a-z0-9])(?<page_id>[a-z0-9]{32,})\.(?<file_extension>[^\?]+)",
 		)
 		.expect("Invalid regular expression")
 		.captures(&page_path)
@@ -212,7 +212,7 @@ fn get_page_list(_manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
 			let chapter = &caps["chapter"];
 			let page_id = &caps["page_id"][..32];
 			let file_extension = &caps["file_extension"];
-			page_path = format!("{chapter}-{page_id}.{file_extension}");
+			page_path = format!("{chapter}{page_id}.{file_extension}");
 		};
 
 		let page_url = Url::Abs(page_path).to_string();


### PR DESCRIPTION
This PR fixes the bug that pages are split into pieces and shuffled.

## Checklist

- [x] Updated source's version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Changes

- Returned original page urls
- Updated version

## Screenshots

| Before | After |
| :-: | :-: |
| ![before](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/90f10a0d-e530-4b7d-9bc1-69af9c091720) | ![after](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/20290cd4-39eb-46a6-95d3-4c9e0cc766e9) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
