### PR TITLE
fix(myreadingmanga): missing last chapter

### DIFF
--- a/src/rust/multi.myreadingmanga/Cargo.lock
+++ b/src/rust/multi.myreadingmanga/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "myreadingmanga"
@@ -66,18 +66,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]

--- a/src/rust/multi.myreadingmanga/res/source.json
+++ b/src/rust/multi.myreadingmanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.myreadingmanga",
 		"lang": "multi",
 		"name": "MyReadingManga",
-		"version": 4,
+		"version": 5,
 		"url": "https://myreadingmanga.info",
 		"nsfw": 2
 	}

--- a/src/rust/multi.myreadingmanga/src/lib.rs
+++ b/src/rust/multi.myreadingmanga/src/lib.rs
@@ -205,7 +205,7 @@ fn get_chapter_list(manga_id: String) -> Result<Vec<Chapter>> {
 		.join(", ");
 
 	let mut chapters = Vec::<Chapter>::new();
-	let mut pages = manga_html.select("a.post-page-numbers").array().len();
+	let mut pages = manga_html.select(".post-page-numbers").array().len();
 	if pages == 0 {
 		pages = 1;
 	}


### PR DESCRIPTION
This PR fixes the bug of the missing last chapter for manga with multiple chapters.

## Checklist

- [x] Updated source's version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Changes

- Corrected the number of chapters
- Updated version

## Screenshots

| Before | After |
| :-: | :-: |
| ![before](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/e0c0fda1-db86-431c-87a8-8185aaa94462) | ![after](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/f3b84e33-ffff-4cf3-b27f-b9fbf5429988) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
