### PR TITLE
feat(nhentai): add all languages option

### DIFF
--- a/src/rust/multi.nhentai/res/source.json
+++ b/src/rust/multi.nhentai/res/source.json
@@ -3,12 +3,15 @@
 		"id": "multi.nhentai",
 		"lang": "multi",
 		"name": "NHentai",
-		"version": 5,
+		"version": 6,
 		"url": "https://nhentai.net/",
 		"nsfw": 2
 	},
 	"languageSelectType": "single",
 	"languages": [
+		{
+			"code": "All"
+		},
 		{
 			"code": "en",
 			"default": true

--- a/src/rust/multi.nhentai/src/lib.rs
+++ b/src/rust/multi.nhentai/src/lib.rs
@@ -31,6 +31,7 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 						"en" => "language:english",
 						"ja" => "language:japanese",
 						"zh" => "language:chinese",
+						"All" => "\"\"",
 						_ => "",
 					})
 					.collect::<Vec<&str>>()


### PR DESCRIPTION
I wanted to filter by all languages as this is the default behavior in the website and tachi.

Checklist:
- [x] Updated source's version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
