### PR TITLE
fix(madara): use alternate method to get listings

### DIFF
--- a/src/rust/madara/Cargo.lock
+++ b/src/rust/madara/Cargo.lock
@@ -115,6 +115,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "harimanga"
+version = "0.1.0"
+dependencies = [
+ "aidoku",
+ "madara_template",
+]
+
+[[package]]
 name = "hentaicb"
 version = "0.1.0"
 dependencies = [

--- a/src/rust/madara/sources/manhuaplus/res/source.json
+++ b/src/rust/madara/sources/manhuaplus/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.manhuaplus",
 		"lang": "en",
 		"name": "ManhuaPlus",
-		"version": 8,
+		"version": 9,
 		"url": "https://manhuaplus.com",
 		"nsfw": 0
 	},

--- a/src/rust/madara/sources/manhuaplus/src/lib.rs
+++ b/src/rust/madara/sources/manhuaplus/src/lib.rs
@@ -10,6 +10,7 @@ fn get_data() -> template::MadaraSiteData {
 	let data: template::MadaraSiteData = template::MadaraSiteData {
 		base_url: String::from("https://manhuaplus.com"),
 		alt_ajax: true,
+		use_ajax_listing: false,
 		image_selector: String::from("li.blocks-gallery-item > figure > img, div.page-break > img, div#chapter-video-frame > p > img, div.text-left > p > img"),
 		..Default::default()
 	};

--- a/src/rust/madara/template/src/template.rs
+++ b/src/rust/madara/template/src/template.rs
@@ -270,8 +270,8 @@ pub fn get_series_page(data: MadaraSiteData, listing: &str, page: i32) -> Result
 		};
 
 		let url = format!(
-			"https://manhuaplus.com/page/{}?s&post_type=wp-manga&m_orderby={}",
-			page, listing
+			"{}/page/{}?s&post_type=wp-manga&m_orderby={}",
+			data.base_url, page, listing
 		);
 
 		return get_search_result(data, url);

--- a/src/rust/madara/template/src/template.rs
+++ b/src/rust/madara/template/src/template.rs
@@ -91,9 +91,7 @@ impl Default for MadaraSiteData {
 			alt_ajax: false,
 			// user agent for all http requests
 			user_agent: None,
-			// use admin-ajax to get listing. Back in mid 2023 the madara wp-theme
-			// was exploited and the admin-ajax was disabled for listing requests.
-			// Sites that still haven't updated their theme will have this set to true.
+			// use admin-ajax to get listings
 			use_ajax_listing: true,
 			// get the manga id from script tag
 			get_manga_id: get_int_manga_id,

--- a/src/rust/madara/template/src/template.rs
+++ b/src/rust/madara/template/src/template.rs
@@ -1,12 +1,12 @@
 use aidoku::{
 	error::Result,
 	prelude::*,
-	std::current_date,
-	std::net::HttpMethod,
-	std::net::Request,
-	std::String,
-	std::StringRef,
-	std::{html::Node, Vec},
+	std::{
+		current_date,
+		html::Node,
+		net::{HttpMethod, Request},
+		String, StringRef, Vec,
+	},
 	Chapter, DeepLink, Filter, Listing, Manga, MangaContentRating, MangaPageResult, MangaStatus,
 	MangaViewer, Page,
 };
@@ -47,6 +47,7 @@ pub struct MadaraSiteData {
 
 	pub alt_ajax: bool,
 	pub user_agent: Option<String>,
+	pub use_ajax_listing: bool,
 
 	pub get_manga_id: fn(String, String, String, Option<String>) -> String,
 	pub viewer: fn(&Node, &Vec<String>) -> MangaViewer,
@@ -90,6 +91,10 @@ impl Default for MadaraSiteData {
 			alt_ajax: false,
 			// user agent for all http requests
 			user_agent: None,
+			// use admin-ajax to get listing. Back in mid 2023 the madara wp-theme
+			// was exploited and the admin-ajax was disabled for listing requests.
+			// Sites that still haven't updated their theme will have this set to true.
+			use_ajax_listing: true,
 			// get the manga id from script tag
 			get_manga_id: get_int_manga_id,
 			// default viewer
@@ -257,6 +262,23 @@ pub fn get_search_result(data: MadaraSiteData, url: String) -> Result<MangaPageR
 }
 
 pub fn get_series_page(data: MadaraSiteData, listing: &str, page: i32) -> Result<MangaPageResult> {
+	// Monkeypatch for now until the source api rewrite
+	if !data.use_ajax_listing {
+		let listing = match listing {
+			"_wp_manga_views" => "views",
+			"_wp_manga_week_views_value" => "trending",
+			"_latest_update" => "latest",
+			_ => "latest",
+		};
+
+		let url = format!(
+			"https://manhuaplus.com/page/{}?s&post_type=wp-manga&m_orderby={}",
+			page, listing
+		);
+
+		return get_search_result(data, url);
+	}
+
 	let url = data.base_url.clone() + "/wp-admin/admin-ajax.php";
 
 	let body_content =  format!("action=madara_load_more&page={}&template=madara-core%2Fcontent%2Fcontent-archive&vars%5Bpaged%5D=1&vars%5Borderby%5D=meta_value_num&vars%5Btemplate%5D=archive&vars%5Bsidebar%5D=full&vars%5Bpost_type%5D=wp-manga&vars%5Bpost_status%5D=publish&vars%5Bmeta_key%5D={}&vars%5Border%5D=desc&vars%5Bmeta_query%5D%5Brelation%5D=OR&vars%5Bmanga_archives_item_layout%5D=big_thumbnail", &page-1, listing);


### PR DESCRIPTION
Quick and dirty fix for some madara sources.

Since most sites work without this, it's not enabled by default, but it should work with all madara sources regardless, but I ain't taking that risk, it can be toggled on a case by case basis.

Closes #632

Checklist:
- [x] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [x] Tested the modifications by running it on the simulator or a test device 
