### PR TITLE
fix(mangadex): do not fail chapter parsing if `externalUrl` is null

### DIFF
--- a/src/rust/multi.mangadex/res/source.json
+++ b/src/rust/multi.mangadex/res/source.json
@@ -4,7 +4,7 @@
 		"lang": "multi",
 		"name": "MangaDex",
 		"url": "https://mangadex.org",
-		"version": 7,
+		"version": 8,
 		"minAppVersion": "0.5"
 	},
 	"languages": [

--- a/src/rust/multi.mangadex/src/parser.rs
+++ b/src/rust/multi.mangadex/src/parser.rs
@@ -240,8 +240,7 @@ pub fn parse_chapter(chapter_object: ObjectRef) -> Result<Chapter> {
 
 	// Fix for Skittyblock/aidoku-community-sources#25
 	let ext_url = attributes.get("externalUrl");
-	if ext_url.is_none()
-		|| ext_url.as_string().is_ok()
+	if ext_url.as_string().is_ok()
 		|| date_updated > crate::helper::current_date()
 	{
 		return Err(aidoku::error::AidokuError {


### PR DESCRIPTION
Looking at #25, it looks like the idea was to filter out chapters where the `externalUrl` is not null; however the current logic filters both when `externalUrl` is `null` and when it's a string (so essentially always I think?). Changed the logic to filter only chapters where `externalUrl` is a string.

A manga where chapters are filtered incorrectly is Houseki no Kuni ([API call](https://api.mangadex.org/manga/cade38b7-64c4-4a29-8e3c-8c283291d6c6/feed?order[volume]=desc&order[chapter]=desc&limit=500&contentRating[]=pornographic&contentRating[]=erotica&contentRating[]=suggestive&contentRating[]=safe&includes[]=scanlation_group&translatedLanguage[]=en), note how `externalUrl` is always null).

I haven't tested this with Aidoku itself (as I do not own a iOS/macOS device), but with a custom client that uses Aidoku's sources; it seems to work properly

Checklist:
- [x] Updated source's version for individual source changes
- [x] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [ ] Tested the modifications by running it on the simulator or a test device 
