### PR TITLE
fix(copymanga): search not working

### DIFF
--- a/src/rust/zh.copymanga/Cargo.lock
+++ b/src/rust/zh.copymanga/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "block-padding"
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "dlmalloc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960a02b0caee913a3df97cd43fcc7370d0695c1dfcd9aca2af3bb9e96c0acd80"
+checksum = "3264b043b8e977326c1ee9e723da2c1f8d09a99df52cacf00b4dbce5ac54414d"
 dependencies = [
  "cfg-if",
  "libc",
@@ -170,7 +170,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -201,42 +201,42 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "regex-automata",
  "regex-syntax",
@@ -244,18 +244,18 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "syn"
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.49"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -293,9 +293,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "version_check"
@@ -314,13 +314,14 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -329,42 +330,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/src/rust/zh.copymanga/Cargo.lock
+++ b/src/rust/zh.copymanga/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "chinese-number",
  "hex",
  "regex",
+ "strum_macros",
  "uuid",
 ]
 
@@ -170,7 +171,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -182,6 +183,12 @@ dependencies = [
  "typenum",
  "version_check",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hex"
@@ -201,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "num-traits"
@@ -258,6 +265,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.64",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.63"
+version = "2.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/zh.copymanga/Cargo.toml
+++ b/src/rust/zh.copymanga/Cargo.toml
@@ -22,4 +22,5 @@ cbc = "0.1.2"
 chinese-number = { version = "0.7.7", default-features = false, features = ["chinese-to-number"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 regex = { version = "1.10.3", default-features = false, features = ["unicode"] }
+strum_macros = "0.26.2"
 uuid = { version = "1.4.1", default-features = false }

--- a/src/rust/zh.copymanga/res/source.json
+++ b/src/rust/zh.copymanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "zh.copymanga",
 		"lang": "zh",
 		"name": "拷貝漫畫",
-		"version": 5,
+		"version": 6,
 		"url": "https://copymanga.site",
 		"urls": [
 			"https://copymanga.site",

--- a/src/rust/zh.copymanga/src/decryptor.rs
+++ b/src/rust/zh.copymanga/src/decryptor.rs
@@ -19,15 +19,12 @@ pub trait EncryptedString {
 impl EncryptedString for String {
 	fn decrypt(self) -> Result<Self> {
 		let encrypted_data = self.as_bytes();
-		// let iv = &encrypted_data[..16];
-		let Some(iv) = encrypted_data.get(..16) else {
-			return Err(to_aidoku_error("Failed to get `iv` from `encrypted_data`"));
-		};
-		let Some(hex_ciphertext) = encrypted_data.get(16..) else {
-			return Err(to_aidoku_error(
-				"Failed to get `hex_ciphertext` from `encrypted_data`",
-			));
-		};
+		let iv = encrypted_data
+			.get(..16)
+			.ok_or_else(|| to_aidoku_error("Failed to get `iv` from `encrypted_data`"))?;
+		let hex_ciphertext = encrypted_data.get(16..).ok_or_else(|| {
+			to_aidoku_error("Failed to get `hex_ciphertext` from `encrypted_data`")
+		})?;
 		let mut ciphertext = hex::decode(hex_ciphertext).map_err(to_aidoku_error)?;
 
 		let plaintext = Aes128CbcDec::new(KEY.into(), iv.into())

--- a/src/rust/zh.copymanga/src/decryptor.rs
+++ b/src/rust/zh.copymanga/src/decryptor.rs
@@ -2,26 +2,58 @@ use aes::{
 	cipher::{block_padding::Pkcs7, BlockDecryptMut, KeyIvInit},
 	Aes128,
 };
-use aidoku::std::String;
+use aidoku::{
+	error::{AidokuError, AidokuErrorKind, Result},
+	prelude::println,
+	std::String,
+};
+use core::marker::Sized;
 
 type Aes128CbcDec = cbc::Decryptor<Aes128>;
 
 const KEY: &[u8] = b"xxxmanga.woo.key";
 
 pub trait EncryptedString {
-	fn decrypt(self) -> String;
+	fn decrypt(self) -> Result<Self>
+	where
+		Self: Sized;
 }
 
 impl EncryptedString for String {
-	fn decrypt(self) -> String {
+	fn decrypt(self) -> Result<Self> {
 		let encrypted_data = self.as_bytes();
-		let iv = &encrypted_data[..16];
-		let mut ciphertext =
-			hex::decode(&encrypted_data[16..]).expect("Failed to hex-decode ciphertext.");
+		// let iv = &encrypted_data[..16];
+		let Some(iv) = encrypted_data.get(..16) else {
+			println!("Failed to get `iv` from `encrypted_data`");
+
+			return Err(AidokuError {
+				reason: AidokuErrorKind::Unimplemented,
+			});
+		};
+		let Some(hex_ciphertext) = encrypted_data.get(16..) else {
+			println!("Failed to get `hex_ciphertext` from `encrypted_data`");
+
+			return Err(AidokuError {
+				reason: AidokuErrorKind::Unimplemented,
+			});
+		};
+		let mut ciphertext = hex::decode(hex_ciphertext).map_err(|e| {
+			println!("{e}");
+
+			AidokuError {
+				reason: AidokuErrorKind::Unimplemented,
+			}
+		})?;
 
 		let plaintext = Aes128CbcDec::new(KEY.into(), iv.into())
 			.decrypt_padded_mut::<Pkcs7>(&mut ciphertext)
-			.expect("Failed to decrypt chapter list");
-		String::from_utf8_lossy(plaintext).into()
+			.map_err(|e| {
+				println!("{e}");
+
+				AidokuError {
+					reason: AidokuErrorKind::Unimplemented,
+				}
+			})?;
+		Ok(Self::from_utf8_lossy(plaintext).into())
 	}
 }

--- a/src/rust/zh.copymanga/src/decryptor.rs
+++ b/src/rust/zh.copymanga/src/decryptor.rs
@@ -1,12 +1,9 @@
+use crate::helper::to_aidoku_error;
 use aes::{
 	cipher::{block_padding::Pkcs7, BlockDecryptMut, KeyIvInit},
 	Aes128,
 };
-use aidoku::{
-	error::{AidokuError, AidokuErrorKind, Result},
-	prelude::println,
-	std::String,
-};
+use aidoku::{error::Result, std::String};
 use core::marker::Sized;
 
 type Aes128CbcDec = cbc::Decryptor<Aes128>;
@@ -24,36 +21,18 @@ impl EncryptedString for String {
 		let encrypted_data = self.as_bytes();
 		// let iv = &encrypted_data[..16];
 		let Some(iv) = encrypted_data.get(..16) else {
-			println!("Failed to get `iv` from `encrypted_data`");
-
-			return Err(AidokuError {
-				reason: AidokuErrorKind::Unimplemented,
-			});
+			return Err(to_aidoku_error("Failed to get `iv` from `encrypted_data`"));
 		};
 		let Some(hex_ciphertext) = encrypted_data.get(16..) else {
-			println!("Failed to get `hex_ciphertext` from `encrypted_data`");
-
-			return Err(AidokuError {
-				reason: AidokuErrorKind::Unimplemented,
-			});
+			return Err(to_aidoku_error(
+				"Failed to get `hex_ciphertext` from `encrypted_data`",
+			));
 		};
-		let mut ciphertext = hex::decode(hex_ciphertext).map_err(|e| {
-			println!("{e}");
-
-			AidokuError {
-				reason: AidokuErrorKind::Unimplemented,
-			}
-		})?;
+		let mut ciphertext = hex::decode(hex_ciphertext).map_err(to_aidoku_error)?;
 
 		let plaintext = Aes128CbcDec::new(KEY.into(), iv.into())
 			.decrypt_padded_mut::<Pkcs7>(&mut ciphertext)
-			.map_err(|e| {
-				println!("{e}");
-
-				AidokuError {
-					reason: AidokuErrorKind::Unimplemented,
-				}
-			})?;
+			.map_err(to_aidoku_error)?;
 		Ok(Self::from_utf8_lossy(plaintext).into())
 	}
 }

--- a/src/rust/zh.copymanga/src/helper/mod.rs
+++ b/src/rust/zh.copymanga/src/helper/mod.rs
@@ -2,6 +2,7 @@ use aidoku::{
 	error::{AidokuError, AidokuErrorKind, Result},
 	prelude::println,
 };
+use core::fmt::Display;
 use regex::Regex as OriginalRegex;
 
 pub struct Regex;
@@ -9,12 +10,14 @@ pub struct Regex;
 impl Regex {
 	#[allow(clippy::new_ret_no_self)]
 	pub fn new<S: AsRef<str>>(pat: S) -> Result<OriginalRegex> {
-		OriginalRegex::new(pat.as_ref()).map_err(|e| {
-			println!("{e}");
+		OriginalRegex::new(pat.as_ref()).map_err(to_aidoku_error)
+	}
+}
 
-			AidokuError {
-				reason: AidokuErrorKind::Unimplemented,
-			}
-		})
+pub fn to_aidoku_error<E: Display>(err: E) -> AidokuError {
+	println!("{err}");
+
+	AidokuError {
+		reason: AidokuErrorKind::Unimplemented,
 	}
 }

--- a/src/rust/zh.copymanga/src/helper/mod.rs
+++ b/src/rust/zh.copymanga/src/helper/mod.rs
@@ -1,0 +1,20 @@
+use aidoku::{
+	error::{AidokuError, AidokuErrorKind, Result},
+	prelude::println,
+};
+use regex::Regex as OriginalRegex;
+
+pub struct Regex;
+
+impl Regex {
+	#[allow(clippy::new_ret_no_self)]
+	pub fn new<S: AsRef<str>>(pat: S) -> Result<OriginalRegex> {
+		OriginalRegex::new(pat.as_ref()).map_err(|e| {
+			println!("{e}");
+
+			AidokuError {
+				reason: AidokuErrorKind::Unimplemented,
+			}
+		})
+	}
+}

--- a/src/rust/zh.copymanga/src/parser.rs
+++ b/src/rust/zh.copymanga/src/parser.rs
@@ -1,7 +1,10 @@
-use crate::{helper::Regex, url::Url};
+use crate::{
+	helper::{to_aidoku_error, Regex},
+	url::Url,
+};
 use aidoku::{
-	error::{AidokuError, AidokuErrorKind, Result},
-	prelude::{format, println},
+	error::{AidokuError, Result},
+	prelude::format,
 	std::{html::Node, json, ArrayRef, ObjectRef, String, ValueRef, Vec},
 	Manga, MangaPageResult, MangaStatus,
 };
@@ -159,20 +162,10 @@ pub trait UuidString {
 impl UuidString for String {
 	fn get_timestamp(&self) -> Result<f64> {
 		let Some(timestamp) = Uuid::from_str(self)
-			.map_err(|e| {
-				println!("{e}");
-
-				AidokuError {
-					reason: AidokuErrorKind::Unimplemented,
-				}
-			})?
+			.map_err(to_aidoku_error)?
 			.get_timestamp()
 		else {
-			println!("Failed to parse UUID to timestamp.");
-
-			return Err(AidokuError {
-				reason: AidokuErrorKind::Unimplemented,
-			});
+			return Err(to_aidoku_error("Failed to parse UUID to timestamp."));
 		};
 		let (integer_part, fractional_part) = timestamp.to_unix();
 

--- a/src/rust/zh.copymanga/src/parser.rs
+++ b/src/rust/zh.copymanga/src/parser.rs
@@ -161,13 +161,11 @@ pub trait UuidString {
 
 impl UuidString for String {
 	fn get_timestamp(&self) -> Result<f64> {
-		let Some(timestamp) = Uuid::from_str(self)
+		let (integer_part, fractional_part) = Uuid::from_str(self)
 			.map_err(to_aidoku_error)?
 			.get_timestamp()
-		else {
-			return Err(to_aidoku_error("Failed to parse UUID to timestamp."));
-		};
-		let (integer_part, fractional_part) = timestamp.to_unix();
+			.ok_or_else(|| to_aidoku_error("Failed to parse UUID to timestamp."))?
+			.to_unix();
 
 		Ok((integer_part as f64) + (fractional_part as f64 * 10e-10))
 	}

--- a/src/rust/zh.copymanga/src/parser.rs
+++ b/src/rust/zh.copymanga/src/parser.rs
@@ -83,7 +83,7 @@ impl MangaArr for ArrayRef {
 				.collect::<Vec<_>>()
 				.join("、");
 
-			let manga_url = Url::Manga(&manga_id).to_string();
+			let manga_url = Url::Manga { id: &manga_id }.to_string();
 
 			let status_code = manga_obj.get("status").as_int().unwrap_or(-1);
 			let status = match status_code {

--- a/src/rust/zh.copymanga/src/url.rs
+++ b/src/rust/zh.copymanga/src/url.rs
@@ -113,7 +113,7 @@ pub enum Url<'a> {
 	/// Manga per response
 	Filters(QueryParameters),
 
-	/// https://copymanga.site/api/kb/web/searcha/comics?offset={}&platform={}&limit={}&q={}&q_type={}
+	/// https://copymanga.site/api/kb/web/searchb/comics?offset={}&platform={}&limit={}&q={}&q_type={}
 	///
 	/// ---
 	///
@@ -290,7 +290,7 @@ impl<'a> Display for Url<'a> {
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
 		match self {
 			Self::Filters(query) => write!(f, "{}/comics?{}", DOMAIN, query),
-			Self::Search(query) => write!(f, "{}/api/kb/web/searcha/comics?{}", DOMAIN, query),
+			Self::Search(query) => write!(f, "{}/api/kb/web/searchb/comics?{}", DOMAIN, query),
 			Self::Manga(manga_id) => write!(f, "{}{}{}", DOMAIN, MANGA_PATH, manga_id),
 			Self::ChapterList(manga_id) => {
 				write!(f, "{}/comicdetail/{}/chapters", DOMAIN, manga_id)

--- a/src/rust/zh.copymanga/src/url.rs
+++ b/src/rust/zh.copymanga/src/url.rs
@@ -1,17 +1,17 @@
 use aidoku::{
 	error::Result,
 	helpers::uri::QueryParameters,
+	prelude::format,
 	std::{html::Node, net::Request, ValueRef, Vec},
 	Filter, FilterType,
 };
 use alloc::string::ToString;
 use core::fmt::Display;
+use strum_macros::Display;
 
+#[derive(Display)]
+#[strum(prefix = "https://copymanga.site")]
 pub enum Url<'a> {
-	/// https://copymanga.site/comics?theme={}&status={}&region={}&ordering={}&offset={}&limit={}
-	///
-	/// ---
-	///
 	/// ## `theme`
 	///
 	/// - : 全部
@@ -111,12 +111,9 @@ pub enum Url<'a> {
 	/// ## `limit`
 	///
 	/// Manga per response
-	Filters(QueryParameters),
+	#[strum(to_string = "/comics?{query}")]
+	Filters { query: QueryParameters },
 
-	/// https://copymanga.site/api/kb/web/searchb/comics?offset={}&platform={}&limit={}&q={}&q_type={}
-	///
-	/// ---
-	///
 	/// ## `offset`
 	///
 	/// `({page} - 1) * {limit}`
@@ -139,16 +136,20 @@ pub enum Url<'a> {
 	/// - `name`: 名稱
 	/// - `author`: 作者
 	/// - `local`: 漢化組
-	Search(QueryParameters),
+	#[strum(to_string = "/api/kb/web/searchb/comics?{query}")]
+	Search { query: QueryParameters },
 
-	/// https://copymanga.site/comic/{manga_id}
-	Manga(&'a str),
+	#[strum(to_string = "/comic/{id}")]
+	Manga { id: &'a str },
 
-	/// https://copymanga.site/comicdetail/{manga_id}/chapters
-	ChapterList(&'a str),
+	#[strum(to_string = "/comicdetail/{id}/chapters")]
+	ChapterList { id: &'a str },
 
-	/// https://copymanga.site/comic/{manga_id}/chapter/{chapter_id}
-	Chapter(&'a str, &'a str),
+	#[strum(to_string = "/comic/{manga_id}/chapter/{chapter_id}")]
+	Chapter {
+		manga_id: &'a str,
+		chapter_id: &'a str,
+	},
 }
 
 /// # 狀態
@@ -286,24 +287,6 @@ impl<'a> Url<'a> {
 	}
 }
 
-impl<'a> Display for Url<'a> {
-	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		match self {
-			Self::Filters(query) => write!(f, "{}/comics?{}", DOMAIN, query),
-			Self::Search(query) => write!(f, "{}/api/kb/web/searchb/comics?{}", DOMAIN, query),
-			Self::Manga(manga_id) => write!(f, "{}{}{}", DOMAIN, MANGA_PATH, manga_id),
-			Self::ChapterList(manga_id) => {
-				write!(f, "{}/comicdetail/{}/chapters", DOMAIN, manga_id)
-			}
-			Self::Chapter(manga_id, chapter_id) => write!(
-				f,
-				"{}{}{}{}{}",
-				DOMAIN, MANGA_PATH, manga_id, CHAPTER_PATH, chapter_id
-			),
-		}
-	}
-}
-
 impl<'a> From<(Vec<Filter>, i32)> for Url<'a> {
 	fn from((filters, page): (Vec<Filter>, i32)) -> Self {
 		let mut genre_index = 0;
@@ -357,7 +340,7 @@ impl<'a> From<(Vec<Filter>, i32)> for Url<'a> {
 					query.push("q", Some(&search_str));
 					query.push_encoded("q_type", None);
 
-					return Url::Search(query);
+					return Url::Search { query };
 				}
 
 				_ => continue,
@@ -369,7 +352,7 @@ impl<'a> From<(Vec<Filter>, i32)> for Url<'a> {
 		query.push_encoded("region", Some(region.to_string().as_str()));
 		query.push_encoded("ordering", Some(sort_by.to_string().as_str()));
 
-		Url::Filters(query)
+		Url::Filters { query }
 	}
 }
 

--- a/src/rust/zh.copymanga/src/url.rs
+++ b/src/rust/zh.copymanga/src/url.rs
@@ -199,7 +199,6 @@ enum Sort {
 	Popularity(bool),
 }
 
-const DOMAIN: &str = "https://copymanga.site";
 pub const MANGA_PATH: &str = "/comic/";
 pub const CHAPTER_PATH: &str = "/chapter/";
 


### PR DESCRIPTION
# fix(copymanga): search not working

This PR fixes the issue that the searching in `zh.copymanga` is not working.

## Checklist

- [x] Updated source’s version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source’s name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Related Issues

- Closes #663

## Changes

- Updated searching URL
- Updated version
- Rewrote enum `Url` for easier maintenance
- Not to panic!

## Screenshots

|             |                                                             Before                                                              |                                                             After                                                              |
| :---------: | :-----------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------: |
| **Search**  | ![search_before](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/a293f3ad-81a5-4368-b60c-6eeb5b8d0166)  | ![search_after](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/160f79c5-6d83-4475-89bc-d84503c3312c)  |
| **Version** | ![version_before](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/0cad7799-eec4-4a41-9e63-371ff99456dd) | ![version_after](https://github.com/Skittyblock/aidoku-community-sources/assets/64679454/b9e403af-b4ee-4c4a-ba9d-f831c1e1d9cb) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
