### PR TITLE
Update FlowerManga website link

### DIFF
--- a/src/rust/madara/sources/flowermanga/res/source.json
+++ b/src/rust/madara/sources/flowermanga/res/source.json
@@ -3,8 +3,8 @@
 		"id": "pt.flowermanga",
 		"lang": "pt-br",
 		"name": "Flower Manga",
-		"version": 1,
-		"url": "https://flowermanga.com",
+		"version": 2,
+		"url": "https://flowermanga.net",
 		"nsfw": 1
 	},
 	"listings": [

--- a/src/rust/madara/sources/flowermanga/src/lib.rs
+++ b/src/rust/madara/sources/flowermanga/src/lib.rs
@@ -8,7 +8,7 @@ use madara_template::template;
 
 fn get_data() -> template::MadaraSiteData {
 	template::MadaraSiteData {
-		base_url: String::from("https://flowermanga.com"),
+		base_url: String::from("https://flowermanga.net"),
 		description_selector: String::from("div.description-summary div p"),
 		alt_ajax: true,
 		..Default::default()


### PR DESCRIPTION
Changed the link to make the source work again.
Old: [flowermanga.com](https://flowermanga.com)
New: [flowermanga.net](https://flowermanga.net)

Checklist:
- [x] Updated source's version for individual source changes
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
