### PR TITLE
Update DemonSect website link

### DIFF
--- a/src/rust/madara/sources/demonsect/res/source.json
+++ b/src/rust/madara/sources/demonsect/res/source.json
@@ -3,8 +3,8 @@
 		"id": "pt-br.demonsect",
 		"lang": "pt-br",
 		"name": "Demon Sect",
-		"version": 1,
-		"url": "https://demonsect.com.br",
+		"version": 2,
+		"url": "https://dsectcomics.org",
 		"nsfw": 2
 	},
 	"listings": [

--- a/src/rust/madara/sources/demonsect/src/lib.rs
+++ b/src/rust/madara/sources/demonsect/src/lib.rs
@@ -9,9 +9,9 @@ use madara_template::template;
 
 fn get_data() -> template::MadaraSiteData {
     template::MadaraSiteData {
-        base_url: String::from("https://demonsect.com.br"),
+        base_url: String::from("https://dsectcomics.org"),
         source_path: String::from("comics"),
-        description_selector: String::from("div.post-content_item div p"),
+        description_selector: String::from("div.post-content-item div p"),
         alt_ajax: true,
         ..Default::default()
     }


### PR DESCRIPTION
Changed the link to make the source work again.
Old: [demonsect.com.br](https://demonsect.com.br)
New: [dsectcomics.org](https://dsectcomics.org)

Checklist:
- [x] Updated source's version for individual source changes
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
