### PR TITLE
MangaTX Domain Change Fixed

### DIFF
--- a/src/rust/madara/sources/mangatx/src/lib.rs
+++ b/src/rust/madara/sources/mangatx/src/lib.rs
@@ -7,7 +7,7 @@ use madara_template::template;
 
 fn get_data() -> template::MadaraSiteData {
 	let data: template::MadaraSiteData = template::MadaraSiteData {
-		base_url: String::from("https://mangatx.com"),
+		base_url: String::from("https://mangatx.to"),
 		alt_ajax: true,
 		..Default::default()
 	};


### PR DESCRIPTION
MangaTX Domain Change from mantagtx.com to mangatx.to

Checklist:
- [ ] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [ ] Set appropriate `nsfw` value
- [ ] Did not change `id` even if a source's name or language were changed
- [ ] Tested the modifications by running it on the simulator or a test device 
