### PR TITLE
MangaTX Domain Change

### DIFF
--- a/src/rust/madara/sources/mangatx/res/source.json
+++ b/src/rust/madara/sources/mangatx/res/source.json
@@ -4,7 +4,7 @@
 		"lang": "en",
 		"name": "MangaTX",
 		"version": 8,
-		"url": "https://mangatx.com",
+		"url": "https://mangatx.to",
 		"nsfw": 0
 	},
 	"listings": [


### PR DESCRIPTION
MangaTX Domain Change from mantagtx.com to mangatx.to

Checklist:
- [ ] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [ ] Set appropriate `nsfw` value
- [ ] Did not change `id` even if a source's name or language were changed
- [ ] Tested the modifications by running it on the simulator or a test device 
