### PR TITLE
fix(copymanga): source not working

### DIFF
--- a/src/rust/zh.copymanga/Cargo.lock
+++ b/src/rust/zh.copymanga/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "regex-automata",
  "regex-syntax",

--- a/src/rust/zh.copymanga/res/source.json
+++ b/src/rust/zh.copymanga/res/source.json
@@ -4,10 +4,7 @@
 		"lang": "zh",
 		"name": "拷貝漫畫",
 		"version": 6,
-		"url": "https://copymanga.site",
 		"urls": [
-			"https://copymanga.site",
-			"https://www.copymanga.site",
 			"https://copymanga.tv",
 			"https://www.copymanga.tv",
 			"https://mangacopy.com",

--- a/src/rust/zh.copymanga/res/source.json
+++ b/src/rust/zh.copymanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "zh.copymanga",
 		"lang": "zh",
 		"name": "拷貝漫畫",
-		"version": 6,
+		"version": 7,
 		"urls": [
 			"https://copymanga.tv",
 			"https://www.copymanga.tv",

--- a/src/rust/zh.copymanga/src/url.rs
+++ b/src/rust/zh.copymanga/src/url.rs
@@ -10,7 +10,7 @@ use core::fmt::Display;
 use strum_macros::Display;
 
 #[derive(Display)]
-#[strum(prefix = "https://copymanga.site")]
+#[strum(prefix = "https://copymanga.tv")]
 pub enum Url<'a> {
 	/// ## `theme`
 	///


### PR DESCRIPTION
This PR fixes the bug that the source `zh.copymanga` is not working.

## Checklist

- [x] Updated source’s version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source’s name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Related Issues

- Closes #717

## Premise

The current domain is invalid.

## Changes

- Removed invalid domains in `source.json`
- Updated the domain in `url.rs`
- Updated source version

## Screenshots

|            |                                              Before                                               |                                               After                                              |
| :--------: | :-----------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------: |
| **Browse** | ![browse-before](https://github.com/user-attachments/assets/6b00cad1-2120-4f8d-861f-e735d73446bc) | ![browse-after](https://github.com/user-attachments/assets/382f5e7f-1747-4287-b2ca-d1602c1063ff) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
