### PR TITLE
fix(tcb): add const for URL and change URL

### DIFF
--- a/src/rust/en.tcbscans/res/source.json
+++ b/src/rust/en.tcbscans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.tcbscans",
 		"lang": "en",
 		"name": "TCB Scans",
-		"version": 3,
+		"version": 4,
 		"url": "https://tcb-backup.bihar-mirchi.com"
 	}
 }

--- a/src/rust/en.tcbscans/res/source.json
+++ b/src/rust/en.tcbscans/res/source.json
@@ -4,6 +4,6 @@
 		"lang": "en",
 		"name": "TCB Scans",
 		"version": 4,
-		"url": "https://tcb-backup.bihar-mirchi.com"
+		"url": "https://tcbscans.com"
 	}
 }

--- a/src/rust/en.tcbscans/res/source.json
+++ b/src/rust/en.tcbscans/res/source.json
@@ -4,6 +4,6 @@
 		"lang": "en",
 		"name": "TCB Scans",
 		"version": 4,
-		"url": "https://tcbscans.com"
+		"url": "https://tcbscans.me"
 	}
 }

--- a/src/rust/en.tcbscans/src/lib.rs
+++ b/src/rust/en.tcbscans/src/lib.rs
@@ -7,9 +7,11 @@ use aidoku::{
 	MangaViewer, Page,
 };
 
+const BASE_URL: &str = "https://tcbscans.me";
+
 #[get_manga_list]
 fn get_manga_list(_filters: Vec<Filter>, _page: i32) -> Result<MangaPageResult> {
-	let html = Request::new("https://tcb-backup.bihar-mirchi.com/projects", HttpMethod::Get).html()?;
+	let html = Request::new(&format!("{}/projects", BASE_URL), HttpMethod::Get).html()?;
 
 	let elements = html.select(".bg-card.border.border-border.rounded.p-3.mb-3");
 
@@ -49,7 +51,7 @@ fn get_manga_list(_filters: Vec<Filter>, _page: i32) -> Result<MangaPageResult> 
 
 #[get_manga_details]
 fn get_manga_details(id: String) -> Result<Manga> {
-	let url = String::from("https://tcb-backup.bihar-mirchi.com") + &id;
+	let url = format!("{}{}", BASE_URL, id);
 	let html = Request::new(url.clone(), HttpMethod::Get).html()?;
 
 	let element = html.select(".order-1.bg-card.border.border-border.rounded.py-3");
@@ -77,7 +79,7 @@ fn get_manga_details(id: String) -> Result<Manga> {
 
 #[get_chapter_list]
 fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
-	let url = String::from("https://tcb-backup.bihar-mirchi.com") + &id;
+	let url = format!("{}{}", BASE_URL, id);
 	let html = Request::new(url, HttpMethod::Get).html()?;
 
 	let elements = html.select(".bg-card.border.border-border.rounded.p-3.mb-3");
@@ -90,7 +92,7 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 		let title = item.select(".text-lg.font-bold:not(.flex)").text().read();
 		let subtitle = item.select(".text-gray-500").text().read();
 		let url_path = item.attr("href").read();
-		let url = String::from("https://tcb-backup.bihar-mirchi.com") + &url_path;
+		let url = format!("{}{}", BASE_URL, url_path);
 
 		let chapter = match title.rsplit_once(' ') {
 			Some((_, str)) => str.parse::<f32>().unwrap_or(-1.0),
@@ -114,7 +116,7 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 
 #[get_page_list]
 fn get_page_list(_manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
-	let url = String::from("https://tcb-backup.bihar-mirchi.com") + &chapter_id;
+	let url = format!("{}{}", BASE_URL, chapter_id);
 	let html = Request::new(url, HttpMethod::Get).html()?;
 
 	let elements = html.select(".flex.flex-col.items-center.justify-center picture img");
@@ -138,8 +140,8 @@ fn get_page_list(_manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
 
 #[handle_url]
 fn handle_url(url: String) -> Result<DeepLink> {
-	// https://tcb-backup.bihar-mirchi.com/mangas/x/x
-	// https://tcb-backup.bihar-mirchi.com/chapters/x/x -> not handled because no manga id
+	// BASE_URL/mangas/x/x
+	// BASE_URL/chapters/x/x -> not handled because no manga id
 	// todo: can get manga url from
 	// ".flex.items-center.justify-center.my-6.gap-2.text-sm.font-bold a".last()
 	let split = url.split('/').collect::<Vec<&str>>();

--- a/src/rust/en.tcbscans/src/lib.rs
+++ b/src/rust/en.tcbscans/src/lib.rs
@@ -11,7 +11,7 @@ const BASE_URL: &str = "https://tcbscans.me";
 
 #[get_manga_list]
 fn get_manga_list(_filters: Vec<Filter>, _page: i32) -> Result<MangaPageResult> {
-	let html = Request::new(&format!("{}/projects", BASE_URL), HttpMethod::Get).html()?;
+	let html = Request::new(format!("{}/projects", BASE_URL), HttpMethod::Get).html()?;
 
 	let elements = html.select(".bg-card.border.border-border.rounded.p-3.mb-3");
 


### PR DESCRIPTION
**Summary:**

I added a constant for the website and updated the URL to the current TCB Scans URL.

The URL in `res/source.json` is now set to `https://tcbscans.com`, as this domain redirects to the current correct version of TCB Scans. If preferred, I can change it to `https://tcbscans.me`, which is the current working website.

This PR should make it easier to fix future TCB Scans URL changes.

**Checklist:**
- [X] Updated source's version for individual source changes
- [X] Updated all sources' versions for template changes
- [X] Set appropriate `nsfw` value
- [X] Did not change `id` even if a source's name or language were changed
- [X] Tested the modifications by running it on the simulator or a test device 

**Screenshots:**

| TCB Overview                                                                                 | Manga Overview                                                                               | Chapter example                                                                              |
| -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| ![IMG_0977](https://github.com/user-attachments/assets/a38747c2-7781-4cf1-b39e-98fff244ec54) | ![IMG_0978](https://github.com/user-attachments/assets/c2f5d59c-219d-49a8-993a-f6ada58c3dc5) | ![IMG_0979](https://github.com/user-attachments/assets/2f4394fc-312f-4616-9ef3-989b9a28e494) |





(works as intended)