### PR TITLE
Migrate manhwax to .org URL

### DIFF
--- a/src/rust/mangastream/sources/manhwax/res/source.json
+++ b/src/rust/mangastream/sources/manhwax/res/source.json
@@ -1,21 +1,21 @@
 {
-  "info": {
-    "id": "en.manhwax",
-    "lang": "en",
-    "name": "ManhwaX",
-    "version": 4,
-    "url": "https://manhwax.org",
-    "nsfw": 2
-  },
-  "listings": [
-    {
-      "name": "Popular"
-    },
-    {
-      "name": "Latest"
-    },
-    {
-      "name": "New"
-    }
-  ]
+	"info": {
+		"id": "en.manhwax",
+		"lang": "en",
+		"name": "ManhwaX",
+		"version": 4,
+		"url": "https://manhwax.org",
+		"nsfw": 2
+	},
+	"listings": [
+		{
+			"name": "Popular"
+		},
+		{
+			"name": "Latest"
+		},
+		{
+			"name": "New"
+		}
+	]
 }

--- a/src/rust/mangastream/sources/manhwax/res/source.json
+++ b/src/rust/mangastream/sources/manhwax/res/source.json
@@ -1,21 +1,21 @@
 {
-	"info": {
-		"id": "en.manhwax",
-		"lang": "en",
-		"name": "ManhwaX",
-		"version": 3,
-		"url": "https://manhwax.com",
-		"nsfw": 2
-	},
-	"listings": [
-		{
-			"name": "Popular"
-		},
-		{
-			"name": "Latest"
-		},
-		{
-			"name": "New"
-		}
-	]
+  "info": {
+    "id": "en.manhwax",
+    "lang": "en",
+    "name": "ManhwaX",
+    "version": 4,
+    "url": "https://manhwax.org",
+    "nsfw": 2
+  },
+  "listings": [
+    {
+      "name": "Popular"
+    },
+    {
+      "name": "Latest"
+    },
+    {
+      "name": "New"
+    }
+  ]
 }

--- a/src/rust/mangastream/sources/manhwax/src/lib.rs
+++ b/src/rust/mangastream/sources/manhwax/src/lib.rs
@@ -8,7 +8,7 @@ use mangastream_template::template::MangaStreamSource;
 
 fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
-		base_url: String::from("https://manhwax.com"),
+		base_url: String::from("https://manhwax.org"),
 		alt_pages: true,
 		..Default::default()
 	}


### PR DESCRIPTION
## Purpose

Fixes #565 

I'm not sure if we should create a new source for this, or the current PR (of just updating the URL) works. I've tested it on a physical device - the website is slow but does work along with search functionalities. 

Checklist:
- [x] Updated source's version for individual source changes
- [] ~Updated all sources' versions for template changes~ N/A
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 
