### PR TITLE
fix(copymanga): search not working

### DIFF
--- a/src/rust/zh.copymanga/Cargo.lock
+++ b/src/rust/zh.copymanga/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -171,7 +171,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "num-traits"
@@ -280,7 +280,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/zh.copymanga/res/source.json
+++ b/src/rust/zh.copymanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "zh.copymanga",
 		"lang": "zh",
 		"name": "拷貝漫畫",
-		"version": 7,
+		"version": 8,
 		"urls": [
 			"https://copymanga.tv",
 			"https://www.copymanga.tv",

--- a/src/rust/zh.copymanga/src/url.rs
+++ b/src/rust/zh.copymanga/src/url.rs
@@ -136,7 +136,7 @@ pub enum Url<'a> {
 	/// - `name`: 名稱
 	/// - `author`: 作者
 	/// - `local`: 漢化組
-	#[strum(to_string = "/api/kb/web/searchb/comics?{query}")]
+	#[strum(to_string = "/api/kb/web/searchba/comics?{query}")]
 	Search { query: QueryParameters },
 
 	#[strum(to_string = "/comic/{id}")]


### PR DESCRIPTION
This PR fixes the bug that the search feature of the source `zh.copymanga` is not working.

## Checklist

- [x] Updated source’s version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source’s name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Related Issues

- Closes #741

## Changes

- Updated source version
- Updated URL of search results

## Screenshots

| Before | After |
| :-: | :-: |
| ![before-search](https://github.com/user-attachments/assets/754f8e05-e8c3-4beb-9f6b-b0eb8b781f16) | ![after-search](https://github.com/user-attachments/assets/284f7c8a-6451-4309-bfc4-4796a5723c9f) |
| ![before-info](https://github.com/user-attachments/assets/ff44963e-d7c2-4f05-81c2-fb791e4835bd) | ![after-info](https://github.com/user-attachments/assets/46591d92-a497-40ac-ac93-c89c8747506c) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
