### PR TITLE
fix(myreadingmanga): source not working on ipad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/rust/node_modules
 
 .idea
 *.iml
+.zed

--- a/src/rust/multi.myreadingmanga/Cargo.lock
+++ b/src/rust/multi.myreadingmanga/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "myreadingmanga"
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]

--- a/src/rust/multi.myreadingmanga/res/source.json
+++ b/src/rust/multi.myreadingmanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.myreadingmanga",
 		"lang": "multi",
 		"name": "MyReadingManga",
-		"version": 8,
+		"version": 9,
 		"url": "https://myreadingmanga.info",
 		"nsfw": 2
 	}

--- a/src/rust/multi.myreadingmanga/src/lib.rs
+++ b/src/rust/multi.myreadingmanga/src/lib.rs
@@ -45,8 +45,9 @@ enum Url<'a> {
 
 const DOMAIN: &str = "https://myreadingmanga.info";
 
-/// Safari on iOS 17.4
-const USER_AGENT: &str = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3.1 Mobile/15E148 Safari/604.1";
+/// Chrome 128 on iOS 17.6
+/// Apple iPhone
+const USER_AGENT: &str = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/128.0.6613.98 Mobile/15E148 Safari/604.1";
 
 /// Sort by: \[More relevant, Newest, Oldest, Random\]
 const SORT: [&str; 4] = [


### PR DESCRIPTION
This PR fixes the bug that the source `multi.myreadingmanga` cannot bypass Cloudflare on iPad.

## Checklist

- [x] Updated source’s version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source’s name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Related Issues

- Closes #748

## Premise

The current user agent cannot bypass Cloudflare on iPad.

## Changes

- Updated source version
- Updated dependencies
- Updated user agent

## Screenshots

| Before | After |
| :-: | :-: |
| ![before-browse](https://github.com/user-attachments/assets/ca95859c-419f-434c-8665-a5db9a9fc2fa) | ![after-browse](https://github.com/user-attachments/assets/a1549a41-79a9-4fc6-9dd8-1c39d5263397) |
| ![before-info](https://github.com/user-attachments/assets/80c31ef3-8260-43db-b6b2-efa0d5aff978) | ![after-info](https://github.com/user-attachments/assets/be6e56ed-fb65-40e9-8aac-a5e246f53587) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
