### PR TITLE
fix(copymanga): search not working

### DIFF
--- a/src/rust/zh.copymanga/Cargo.lock
+++ b/src/rust/zh.copymanga/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "block-padding"
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -171,7 +171,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "num-traits"
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -280,7 +280,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -313,9 +313,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "uuid"

--- a/src/rust/zh.copymanga/res/source.json
+++ b/src/rust/zh.copymanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "zh.copymanga",
 		"lang": "zh",
 		"name": "拷貝漫畫",
-		"version": 8,
+		"version": 9,
 		"urls": [
 			"https://copymanga.tv",
 			"https://www.copymanga.tv",


### PR DESCRIPTION
This PR fixes the bug that the search feature of `zh.copymanga` is not working.

## Checklist

- [x] Updated source’s version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source’s name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Related Issues

- Closes #764

## Changes

- Updated source version
- Updated dependencies
- Rewrote URL of search

## Screenshots

|                                              Before                                               |                                              After                                               |
|:-----------------------------------------------------------------------------------------------: |:----------------------------------------------------------------------------------------------: |
|![before-search](https://github.com/user-attachments/assets/429e3287-db38-4a36-b509-3286db69acba) |![after-search](https://github.com/user-attachments/assets/777b201e-a5af-41b9-b0ad-0312126fd7ab) |
|![brfore-info](https://github.com/user-attachments/assets/2aa95417-ff70-465f-be58-18da57f67160)  |![after-info](https://github.com/user-attachments/assets/4ac74ad7-45e9-40a7-af28-f9a2ecffba82)  |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
