### PR TITLE
fix(asura): broken chapter image indices

### DIFF
--- a/src/rust/en.asurascans/res/source.json
+++ b/src/rust/en.asurascans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.asurascans",
 		"lang": "en",
 		"name": "Asura Scans",
-		"version": 3,
+		"version": 4,
 		"url": "https://asuracomic.net",
 		"nsfw": 0
 	}

--- a/src/rust/en.asurascans/src/lib.rs
+++ b/src/rust/en.asurascans/src/lib.rs
@@ -310,7 +310,13 @@ fn get_page_list(manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
 		let index = {
 			let before = url.substring_after_last('/').unwrap_or("");
 			let after = before.substring_before('.').unwrap_or("");
-			after.parse::<i32>().unwrap_or(-1)
+
+			let cleaned_after = after
+				.chars()
+				.filter(|c| c.is_ascii_digit())
+				.collect::<String>();
+
+			cleaned_after.parse::<i32>().unwrap_or(-1)
 		};
 
 		pages.push(Page {


### PR DESCRIPTION
Filter out non ascii digits from parsed file name

If it breaks again, we can just stop trying to parse out the image index from the file name, and just rely on the dom's image element order.

Checklist:
- [x] Updated source's version for individual source changes
- [x] Tested the modifications by running it on the simulator or a test device