### PR TITLE
fix(reaperscans): search and sorting

### DIFF
--- a/src/rust/en.reaperscans/res/filters.json
+++ b/src/rust/en.reaperscans/res/filters.json
@@ -69,14 +69,18 @@
 		"default": 0
 	},
 	{
-		"type": "select",
+		"type": "sort",
 		"name": "Order By",
+		"canAscend": true,
 		"options": [
 			"Last Updated",
 			"Popular",
 			"Alphabetical",
 			"Oldest"
 		],
-		"default": 0
+		"default": {
+			"index": 0,
+			"ascending": false
+		}
 	}
 ]

--- a/src/rust/en.reaperscans/res/source.json
+++ b/src/rust/en.reaperscans/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.reaperscans",
 		"lang": "en",
 		"name": "Reaper Scans",
-		"version": 10,
+		"version": 11,
 		"url": "https://reaperscans.com",
 		"nsfw": 0
 	}


### PR DESCRIPTION
Search was broken before since reaper's api doesn't like it when you send an empty url query param.

Also, made the sort filter an actual sort filter with support for acsending and descending order.

Checklist:

- [x] Updated source's version for individual source changes
- [x] Tested the modifications by running it on the simulator or a test device
