### PR TITLE
fix(mangademon): new url and cf handling

### DIFF
--- a/src/rust/en.mangademon/res/source.json
+++ b/src/rust/en.mangademon/res/source.json
@@ -2,9 +2,9 @@
 	"info": {
 		"id": "en.mangademon",
 		"lang": "en",
-		"name": "Manga Demon",
-		"version": 4,
-		"url": "https://ciorti.online",
+		"name": "MangaDemon",
+		"version": 5,
+		"url": "https://demonicscans.org",
 		"nsfw": 0
 	},
 	"listings": [

--- a/src/rust/en.mangademon/src/lib.rs
+++ b/src/rust/en.mangademon/src/lib.rs
@@ -17,7 +17,8 @@ use aidoku::{
 use helper::*;
 use parser::*;
 
-const BASE_URL: &str = "https://ciorti.online";
+const BASE_URL: &str = "https://demonicscans.org";
+const USER_AGENT: &str = "Aidoku";
 
 #[get_manga_list]
 fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
@@ -68,7 +69,9 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 		}
 	}
 
-	let html = Request::new(url, HttpMethod::Get).html()?;
+	let html = Request::new(url, HttpMethod::Get)
+		.header("User-Agent", USER_AGENT)
+		.html()?;
 
 	Ok(parse_manga_list(html, searching))
 }
@@ -77,7 +80,9 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 fn get_manga_listing(_listing: Listing, page: i32) -> Result<MangaPageResult> {
 	let url = format!("{}/lastupdates.php?list={}", BASE_URL, page);
 
-	let html = Request::new(url, HttpMethod::Get).html()?;
+	let html = Request::new(url, HttpMethod::Get)
+		.header("User-Agent", USER_AGENT)
+		.html()?;
 
 	Ok(parse_latest_manga_list(html))
 }
@@ -86,7 +91,9 @@ fn get_manga_listing(_listing: Listing, page: i32) -> Result<MangaPageResult> {
 fn get_manga_details(manga_id: String) -> Result<Manga> {
 	let url = get_manga_url(&manga_id);
 
-	let html = Request::new(url.clone(), HttpMethod::Get).html()?;
+	let html = Request::new(url.clone(), HttpMethod::Get)
+		.header("User-Agent", USER_AGENT)
+		.html()?;
 
 	Ok(parse_manga_details(html, url))
 }
@@ -95,7 +102,9 @@ fn get_manga_details(manga_id: String) -> Result<Manga> {
 fn get_chapter_list(manga_id: String) -> Result<Vec<Chapter>> {
 	let url = get_manga_url(&manga_id);
 
-	let html = Request::new(url, HttpMethod::Get).html()?;
+	let html = Request::new(url, HttpMethod::Get)
+		.header("User-Agent", USER_AGENT)
+		.html()?;
 
 	Ok(parse_chapter_list(html))
 }
@@ -104,14 +113,18 @@ fn get_chapter_list(manga_id: String) -> Result<Vec<Chapter>> {
 fn get_page_list(_manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
 	let chap_url = get_chapter_url(&chapter_id)?;
 
-	let html = Request::new(chap_url, HttpMethod::Get).html()?;
+	let html = Request::new(chap_url, HttpMethod::Get)
+		.header("User-Agent", USER_AGENT)
+		.html()?;
 
 	Ok(parse_page_list(html))
 }
 
 #[modify_image_request]
 fn modify_image_request(request: Request) {
-	request.header("Referer", BASE_URL);
+	request
+		.header("Referer", BASE_URL)
+		.header("User-Agent", USER_AGENT);
 }
 
 #[handle_url]


### PR DESCRIPTION
## Checklist
- [x] Updated source's version for individual source changes
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 

## Changes
- updated the url
- looks like cloudflare was also blocking it, so i needed to add a user agent to requests
  - aidoku should probably change the default user agent
 
closes #853 