### PR TITLE
fix(mangasorigines): details and chapter loading

### DIFF
--- a/src/rust/madara/sources/mangasorigines/res/filters.json
+++ b/src/rust/madara/sources/mangasorigines/res/filters.json
@@ -3,28 +3,6 @@
 		"type": "title"
 	},
 	{
-		"type": "group",
-		"name": "Status",
-		"filters": [
-			{
-				"type": "check",
-				"name": "En cours"
-			},
-			{
-				"type": "check",
-				"name": "En pause"
-			},
-			{
-				"type": "check",
-				"name": "Annulé"
-			},
-			{
-				"type": "check",
-				"name": "Terminé"
-			}
-		]
-	},
-	{
 		"type": "select",
 		"name": "Genre Condition",
 		"options": [

--- a/src/rust/madara/sources/mangasorigines/res/source.json
+++ b/src/rust/madara/sources/mangasorigines/res/source.json
@@ -3,7 +3,7 @@
 		"id": "fr.mangasorigines",
 		"lang": "fr",
 		"name": "Mangas Origines",
-		"version": 1,
+		"version": 2,
 		"url": "https://mangas-origines.fr",
 		"nsfw": 0
 	},

--- a/src/rust/madara/sources/mangasorigines/src/lib.rs
+++ b/src/rust/madara/sources/mangasorigines/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use aidoku::{
 	error::Result, prelude::*, std::net::Request, std::String, std::Vec, Chapter, DeepLink, Filter,
-	Listing, Manga, MangaPageResult, MangaStatus, Page,
+	Listing, Manga, MangaPageResult, Page,
 };
 use madara_template::template;
 
@@ -9,29 +9,11 @@ fn get_data() -> template::MadaraSiteData {
 	let data: template::MadaraSiteData = template::MadaraSiteData {
 		base_url: String::from("https://mangas-origines.fr"),
 		lang: String::from("fr"),
-		description_selector: String::from("div.manga-excerpt p"),
-		status_filter_ongoing: String::from("En cours"),
-		status_filter_completed: String::from("Terminé"),
-		status_filter_cancelled: String::from("Annulé"),
-		status_filter_on_hold: String::from("En pause"),
+		source_path: "oeuvre".into(),
+		description_selector: "div.summary__content > p".into(),
+		author_selector: "div.manga-authors > a".into(),
 		popular: String::from("Populaire"),
 		trending: String::from("Tendance"),
-		status: |html| {
-			let status_str = html
-				.select("div.post-content_item:contains(Statut) div.summary-content")
-				.text()
-				.read()
-				.to_lowercase();
-			let mut status_str = status_str.chars();
-			status_str.next();
-			match status_str.as_str() {
-				"en cours" => MangaStatus::Ongoing,
-				"complété" => MangaStatus::Completed,
-				"annulé" => MangaStatus::Cancelled,
-				"en pause" => MangaStatus::Hiatus,
-				_ => MangaStatus::Unknown,
-			}
-		},
 		alt_ajax: true,
 		..Default::default()
 	};

--- a/src/rust/madara/template/src/helper.rs
+++ b/src/rust/madara/template/src/helper.rs
@@ -203,6 +203,15 @@ pub fn get_int_manga_id(
 	req = add_user_agent_header(req, &user_agent);
 
 	if let Ok(html) = req.html() {
+		let data_id = html
+			.select("div[id^=manga-chapters-holder]")
+			.first()
+			.attr("data-id")
+			.read();
+		if !data_id.is_empty() {
+			return data_id;
+		}
+
 		let id_html = html.select("script#wp-manga-js-extra").html().read();
 		let id = &id_html[id_html.find("manga_id").expect("Could not find manga_id") + 11
 			..id_html.find("\"}").expect("Could not find end of manga_id")];


### PR DESCRIPTION
## Checklist
- [x] Updated source's version for individual source changes
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 

## Changes
madara template was fetching the id in some js, but looks like this source loads the js from base64 so it didn't exist. i think tachi's template takes the id from the chapter wrapper, which i added in. hopefully doesn't break any other sources...

also doesn't look like this source supports filtering by status / doesn't display status on the manga pages

closes #854 