### PR TITLE
fix(batoto): better chapter/volume number parsing

### DIFF
--- a/src/rust/multi.batoto/Cargo.toml
+++ b/src/rust/multi.batoto/Cargo.toml
@@ -25,3 +25,4 @@ cbc = { version = "0.1.2", features = ["block-padding", "alloc"] }
 evpkdf = { git = "https://github.com/EnoughTea/evpkdf", branch = "to_digest_0.10" }
 md-5 = { version = "0.10.1", default-features = false }
 digest = { version = "0.10.3", features = ["alloc"] }
+chapter-recognition = { git = "https://github.com/beer-psi/chapter-recognition" }

--- a/src/rust/multi.batoto/res/source.json
+++ b/src/rust/multi.batoto/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.batoto",
 		"lang": "multi",
 		"name": "Bato.to",
-		"version": 4,
+		"version": 5,
 		"urls": [
 			"https://bato.to",
 			"https://wto.to"

--- a/src/rust/multi.batoto/src/lib.rs
+++ b/src/rust/multi.batoto/src/lib.rs
@@ -84,7 +84,7 @@ fn get_chapter_list(manga_id: String) -> Result<Vec<Chapter>> {
 		url.push_str(&manga_id);
 	}
 	let html = Request::new(url.as_str(), HttpMethod::Get).html()?;
-	parser::get_chaper_list(html)
+	parser::get_chapter_list(html)
 }
 
 #[get_page_list]

--- a/src/rust/multi.batoto/src/parser.rs
+++ b/src/rust/multi.batoto/src/parser.rs
@@ -165,19 +165,16 @@ pub fn get_chapter_list(obj: Node) -> Result<Vec<Chapter>> {
 			.replace(": ", "");
 
 		let name = chapter_node.select(".chapt b").text().read();
-		if !name.contains("Chapter") && !name.contains("Episode") && title.is_empty() {
-			title = name.to_string();
-		}
+		let ch_num_pfxs = ["Chapter", "Episode"];
 
 		// Volume & Chapter
-		let title_spl = {
-			if name.contains("Episode") {
-				"Episode"
-			} else {
-				"Chapter"
-			}
-		};
-		let vol_and_chap = name.split(title_spl).collect::<Vec<&str>>();
+		let title_spl = ch_num_pfxs.iter().find(|s| name.contains(*s));
+		if title_spl.is_none() && title.is_empty() {
+			title = name.to_string();
+		}
+		let vol_and_chap = name
+			.split(*title_spl.unwrap_or(&"Chapter"))
+			.collect::<Vec<&str>>();
 		let chapter = match vol_and_chap.get(1) {
 			Some(chap_str) => chap_str
 				.trim()

--- a/src/rust/multi.batoto/src/parser.rs
+++ b/src/rust/multi.batoto/src/parser.rs
@@ -7,8 +7,8 @@ use aidoku::{
 };
 
 use crate::helper::{i32_to_string, lang_encoder, urlencode};
+use chapter_recognition::{parse_chapter_number, parse_volume_number};
 extern crate alloc;
-use alloc::string::ToString;
 
 pub fn parse_listing(html: &Node, result: &mut Vec<Manga>) {
 	for page in html.select(".col.item").array() {
@@ -158,38 +158,17 @@ pub fn get_chapter_list(obj: Node) -> Result<Vec<Chapter>> {
 			.read()
 			.replace("/chapter/", "");
 		// Title
-		let mut title = chapter_node
+		let title = chapter_node
 			.select(".chapt span")
 			.text()
 			.read()
 			.replace(": ", "");
 
 		let name = chapter_node.select(".chapt b").text().read();
-		let ch_num_pfxs = ["Chapter", "Episode"];
 
 		// Volume & Chapter
-		let title_spl = ch_num_pfxs.iter().find(|s| name.contains(*s));
-		if title_spl.is_none() && title.is_empty() {
-			title = name.to_string();
-		}
-		let vol_and_chap = name
-			.split(*title_spl.unwrap_or(&"Chapter"))
-			.collect::<Vec<&str>>();
-		let chapter = match vol_and_chap.get(1) {
-			Some(chap_str) => chap_str
-				.trim()
-				.split(' ')
-				.next()
-				.unwrap_or("-1.0")
-				.parse::<f32>()
-				.unwrap_or(-1.0),
-			None => -1.0,
-		};
-		let volume = vol_and_chap[0]
-			.replace("Volume", "")
-			.trim()
-			.parse::<f32>()
-			.unwrap_or(-1.0);
+		let chapter = parse_chapter_number(&title, &name);
+		let volume = parse_volume_number(&title, &name);
 
 		let time_str = chapter_node.select(".extra i.ps-3").text().read();
 		// Date_updated

--- a/src/rust/multi.batoto/src/parser.rs
+++ b/src/rust/multi.batoto/src/parser.rs
@@ -147,7 +147,7 @@ pub fn parse_manga(obj: Node, id: String) -> Result<Manga> {
 	})
 }
 
-pub fn get_chaper_list(obj: Node) -> Result<Vec<Chapter>> {
+pub fn get_chapter_list(obj: Node) -> Result<Vec<Chapter>> {
 	let mut chapters: Vec<Chapter> = Vec::new();
 	for item in obj.select(".item").array() {
 		let chapter_node = item.as_node().expect("node array");
@@ -165,12 +165,19 @@ pub fn get_chaper_list(obj: Node) -> Result<Vec<Chapter>> {
 			.replace(": ", "");
 
 		let name = chapter_node.select(".chapt b").text().read();
-		if !name.contains("Chapter") && title.is_empty() {
+		if !name.contains("Chapter") && !name.contains("Episode") && title.is_empty() {
 			title = name.to_string();
 		}
 
 		// Volume & Chapter
-		let vol_and_chap = name.split("Chapter").collect::<Vec<&str>>();
+		let title_spl = {
+			if name.contains("Episode") {
+				"Episode"
+			} else {
+				"Chapter"
+			}
+		};
+		let vol_and_chap = name.split(title_spl).collect::<Vec<&str>>();
 		let chapter = match vol_and_chap.get(1) {
 			Some(chap_str) => chap_str
 				.trim()


### PR DESCRIPTION
minor: much improved parsing of chapter & volume numbers courtesy of [beer-psi/chapter-recognition](https://github.com/beer-psi/chapter-recognition)

added dependency: [beer-psi/chapter-recognition](https://github.com/beer-psi/chapter-recognition)

also fixed misspelling of "chapter"

Checklist:
- [x] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 




