### PR TITLE
fix(myreadingmanga): images not loading

### DIFF
--- a/src/rust/multi.myreadingmanga/Cargo.lock
+++ b/src/rust/multi.myreadingmanga/Cargo.lock
@@ -50,9 +50,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "dlmalloc"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5e0d321d61de16390ed273b647ce51605b575916d3c25e6ddf27a1e140035"
+checksum = "8cff88b751e7a276c4ab0e222c3f355190adc6dde9ce39c851db39da34990df7"
 dependencies = [
  "cfg-if",
  "libc",

--- a/src/rust/multi.myreadingmanga/res/source.json
+++ b/src/rust/multi.myreadingmanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "multi.myreadingmanga",
 		"lang": "multi",
 		"name": "MyReadingManga",
-		"version": 10,
+		"version": 11,
 		"url": "https://myreadingmanga.info",
 		"nsfw": 2
 	}

--- a/src/rust/multi.myreadingmanga/src/lib.rs
+++ b/src/rust/multi.myreadingmanga/src/lib.rs
@@ -99,7 +99,7 @@ fn get_manga_list(filters: Vec<Filter>, page: i32) -> Result<MangaPageResult> {
 
 		let cover_url = manga_node
 			.select("img")
-			.attr("data-src")
+			.attr("src")
 			.read()
 			.replace("-200x280", "")
 			.percent_encode(false);
@@ -140,7 +140,7 @@ fn get_manga_details(manga_id: String) -> Result<Manga> {
 	let cover = request_get(&search_title_url)
 		.html()?
 		.select(manga_selector)
-		.attr("data-src")
+		.attr("src")
 		.read()
 		.replace("-200x280", "");
 
@@ -275,7 +275,7 @@ fn get_page_list(manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
 	let mut pages = Vec::<Page>::new();
 	let page_nodes = chapter_html.select("img.img-myreadingmanga");
 	for (page_index, page_value) in page_nodes.array().enumerate() {
-		let page_url = page_value.as_node()?.attr("data-src").read();
+		let page_url = page_value.as_node()?.attr("src").read();
 
 		pages.push(Page {
 			index: page_index as i32,


### PR DESCRIPTION
This PR fixes the bug that the images in the source `multi.myreadingmaga` are not loading.

## Checklist

- [x] Updated source’s version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source’s name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Premise

The website changed the attribute that contained the image URL.

## Changes

- Fixed the issue that images failed to load

## Screenshots

|                                              Before                                               |                                              After                                               |
|:-----------------------------------------------------------------------------------------------: |:----------------------------------------------------------------------------------------------: |
|![browse-before](https://github.com/user-attachments/assets/6550ceaf-efdc-45ab-bd8a-0ebad06f8f6b) |![browse-after](https://github.com/user-attachments/assets/ff8d2a93-a9ed-4970-bc3b-a2c58b3a3818) |
|![page-before](https://github.com/user-attachments/assets/0e35340b-4eff-4ae6-8f6c-2e6b9cb623f4)  |![page-after](https://github.com/user-attachments/assets/271cd4a5-bd53-472b-b4ca-49f0c2a1b4c6)  |
|![info-before](https://github.com/user-attachments/assets/aeb2992a-a560-453c-9c32-3724427c4711)  |![info-after](https://github.com/user-attachments/assets/dccaa9bf-659d-47f0-9496-cc92f28610da)  |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
