### PR TITLE
Fix weebcentral images not loading

### DIFF
--- a/src/rust/en.weebcentral/src/lib.rs
+++ b/src/rust/en.weebcentral/src/lib.rs
@@ -315,6 +315,11 @@ fn get_page_list(_manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
 	Ok(pages)
 }
 
+#[modify_image_request]
+fn modify_image_request(request: Request) {
+	request.header("Referer", "https://weebcentral.com/");
+}
+
 // i don't care enough to implement this rn
 // #[handle_url]
 // fn handle_url(url: String) -> Result<DeepLink> {


### PR DESCRIPTION
Fixes https://github.com/Skittyblock/aidoku-community-sources/issues/920

## Problem 

Try to open this URL directly - https://scans.lastation.us/manga/Sono-Bisque-Doll-Wa-Koi-Wo-Suru/0114-021.png

You will see cloudflare error. The only way to fix the cloudflare error is by adding `Referrer: 'https://weebcentral.com/'` to the request headers. 

This PR does just that. 

To check if this fix works, try opening OPM (where this behaviour is not present), and My Dress Up Darling (where it does get blocked) - it should work for both. 

Checklist:
- [ ] Updated source's version for individual source changes
- [ ] Updated all sources' versions for template changes
- [ ] Set appropriate `nsfw` value
- [ ] Did not change `id` even if a source's name or language were changed
- [ ] Tested the modifications by running it on the simulator or a test device 
