### PR TITLE
fix(mangabox): handle multiple pages and listings

### DIFF
--- a/src/rust/mangabox/sources/mangabat/res/source.json
+++ b/src/rust/mangabox/sources/mangabat/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.mangabat",
 		"lang": "en",
 		"name": "MangaBat",
-		"version": 3,
+		"version": 4,
 		"nsfw": 1,
 		"url": "https://www.mangabats.com"
 	},

--- a/src/rust/mangabox/sources/manganato/res/source.json
+++ b/src/rust/mangabox/sources/manganato/res/source.json
@@ -3,9 +3,9 @@
 		"id": "en.manganato",
 		"lang": "en",
 		"name": "MangaNato",
-		"version": 2,
+		"version": 3,
 		"nsfw": 1,
-		"url": "https://www.natomanga.com"
+		"url": "https://www.manganato.gg"
 	},
 	"listings": [
 		{

--- a/src/rust/mangabox/sources/manganato/src/lib.rs
+++ b/src/rust/mangabox/sources/manganato/src/lib.rs
@@ -7,7 +7,7 @@ use aidoku::{
 };
 use mangabox_template::template;
 
-const BASE_URL: &str = "https://www.natomanga.com";
+const BASE_URL: &str = "https://www.manganato.gg";
 const ITEM_SELECTOR: &str = ".panel_story_list .story_item, .list-truyen-item-wrap";
 const GENRES: [&str; 41] = [
 	"all",

--- a/src/rust/mangabox/template/src/helper.rs
+++ b/src/rust/mangabox/template/src/helper.rs
@@ -143,7 +143,7 @@ pub fn get_search_url(
 	} else {
 		let mut title = None;
 		let mut url_filter = 0;
-		let mut genre = String::new();
+		let mut genre = String::from("all");
 
 		for filter in filters {
 			match filter.kind {
@@ -263,7 +263,7 @@ pub fn stupidencode(string: String) -> String {
 	for c in string.chars() {
 		if c.is_alphanumeric() {
 			result.push(c.to_ascii_lowercase());
-		} else if c == ' ' {
+		} else if [' ', '-', '_', '\'', '’'].contains(&c) {
 			result.push('_');
 		}
 	}


### PR DESCRIPTION
## checklist
- [x] Updated all sources' versions for template changes
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device 

## changes
- updated manganato url (natomanga.com has some weird cloudflare issues i couldn't get past)
- fixed some special character search encoding
- fixed `has_more` for manga pages
- fixed listings for manganato and mangabat

closes #918