### PR TITLE
fix(copymanga): source not working

### DIFF
--- a/src/rust/zh.copymanga/res/source.json
+++ b/src/rust/zh.copymanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "zh.copymanga",
 		"lang": "zh",
 		"name": "拷貝漫畫",
-		"version": 11,
+		"version": 12,
 		"urls": ["https://mangacopy.com", "https://www.mangacopy.com"],
 		"nsfw": 1
 	}

--- a/src/rust/zh.copymanga/src/url.rs
+++ b/src/rust/zh.copymanga/src/url.rs
@@ -328,11 +328,19 @@ const LIMIT: i32 = 20;
 
 impl Url<'_> {
 	pub fn get_html(self) -> Result<Node> {
-		Request::get(self.to_string()).html()
+		self.get().html()
 	}
 
 	pub fn get_json(self) -> Result<ValueRef> {
-		Request::get(self.to_string()).json()
+		self.get().json()
+	}
+
+	fn get(self) -> Request {
+		Request::get(self.to_string()).header(
+			"User-Agent",
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_4) \
+			 AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15",
+		)
 	}
 }
 


### PR DESCRIPTION
This PR fixes the issue where the source is not working.

## Checklist

- [x] Updated source’s version for individual source changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source’s name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device

## Premise

The default user agent is different on Aidoku [0.6.11](https://github.com/Aidoku/Aidoku/commit/1f6253b598f0a9ef5731640e5dbe9315d29573ad).

## Changes

- Set user agent for requests

## Screenshots

| Before | After |
| :-: | :-: |
| ![before-browse](https://github.com/user-attachments/assets/8a4b1da6-4df2-492e-a366-16364e09f12b) | ![after-browse](https://github.com/user-attachments/assets/4332859f-59e1-4919-a0a7-2c3102671289) |
| ![before-info](https://github.com/user-attachments/assets/bdf16e70-574e-4a9e-89f7-502b209b98a6) | ![after-info](https://github.com/user-attachments/assets/c961da4e-3667-4910-9755-72212bae9718) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**