### PR TITLE
fix(weebcentral): use correct CSS selector on `get_page_list`

### DIFF
--- a/src/rust/en.weebcentral/res/source.json
+++ b/src/rust/en.weebcentral/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.weebcentral",
 		"lang": "en",
 		"name": "Weeb Central",
-		"version": 4,
+		"version": 5,
 		"url": "https://weebcentral.com",
 		"nsfw": 1
 	}

--- a/src/rust/en.weebcentral/src/lib.rs
+++ b/src/rust/en.weebcentral/src/lib.rs
@@ -299,7 +299,7 @@ fn get_page_list(_manga_id: String, chapter_id: String) -> Result<Vec<Page>> {
 	let mut pages = Vec::new();
 
 	for (idx, element) in html
-		.select("section[x-data~=scroll] > img")
+		.select("section[x-data*=scroll] > img")
 		.array()
 		.enumerate()
 	{


### PR DESCRIPTION
The HTML of the page downloaded in the `get_page_list` method looks something like this:
```html
<section
	x-data="{ 
		scrollDown() { window.scrollBy({ top: window.innerHeight * 0.75, behavior: 'smooth' }); },
		scrollUp() { window.scrollBy({ top: -window.innerHeight * 0.75, behavior: 'smooth' }); },
		handleClick(e) {
			const clickX = e.clientX;
			const sectionWidth = e.currentTarget.getBoundingClientRect().width;
			const isLeftHalf = clickX < sectionWidth / 2;

			if (isLeftHalf) {
				this.scrollUp();
			} else {
				this.scrollDown();
			}
		},
	}"
	<!-- some other fields -->
	>
```

The current code used the `~=` matcher to check if `scroll` is present on the `x-data` attribute, but the matcher is intended to ([reference](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors)):
> [match] elements with an attribute name of attr whose value is a whitespace-separated list of words, one of which is _exactly_ value.

I'm not sure why it works with SwiftSoup, but it breaks when using Servo's CSS engine (used by [`scraper`](https://github.com/rust-scraper/scraper)) because it only matches whole words. I've changed for it to use the `*=` matcher, which should keep the same behavior on SwiftSoup but work on other CSS implementations.

I couldn't test this on Aidoku, so I'd appreciate if someone tested 😄 

Checklist:
- [x] Updated source's version for individual source changes
- [x] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [ ] Tested the modifications by running it on the simulator or a test device 
