### PR TITLE
chore: fix sources using let chains

### DIFF
--- a/src/rust/mmrcms/sources/mangaid/Cargo.toml
+++ b/src/rust/mmrcms/sources/mangaid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mangaid"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/rust/mmrcms/sources/mangaid/src/lib.rs
+++ b/src/rust/mmrcms/sources/mangaid/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(let_chains)]
 use aidoku::{
 	error::Result,
 	prelude::*,
@@ -43,7 +42,8 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 #[get_page_list]
 fn get_page_list(manga_id: String, id: String) -> Result<Vec<Page>> {
 	let cdn = if let Ok(default) = defaults_get("useCDN")
-				 && let Ok(cdn) = default.as_string().map(|v| v.read()) {
+		&& let Ok(cdn) = default.as_string().map(|v| v.read())
+	{
 		cdn
 	} else {
 		String::from("?cdn=off")

--- a/src/rust/mmrcms/template/Cargo.toml
+++ b/src/rust/mmrcms/template/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mmrcms_template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/src/rust/mmrcms/template/src/lib.rs
+++ b/src/rust/mmrcms/template/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![feature(stmt_expr_attributes)]
-#![feature(let_chains)]
 pub mod helper;
 pub mod template;
 

--- a/src/rust/multi.mangadex/Cargo.toml
+++ b/src/rust/multi.mangadex/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mangadex-aidoku"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/rust/multi.mangadex/src/helper.rs
+++ b/src/rust/multi.mangadex/src/helper.rs
@@ -1,4 +1,4 @@
-use aidoku::std::{net::Request, String, ValueRef, Vec};
+use aidoku::std::{String, ValueRef, Vec, net::Request};
 
 pub fn urlencode(string: String) -> String {
 	let mut result: Vec<u8> = Vec::with_capacity(string.len() * 3);
@@ -21,7 +21,7 @@ pub fn urlencode(string: String) -> String {
 }
 
 #[link(wasm_import_module = "net")]
-extern "C" {
+unsafe extern "C" {
 	#[link_name = "send"]
 	fn request_send(rd: i32);
 	#[link_name = "json"]
@@ -36,7 +36,7 @@ extern "C" {
 }
 
 #[link(wasm_import_module = "std")]
-extern "C" {
+unsafe extern "C" {
 	fn destroy(rid: i32);
 	fn create_date(value: f64) -> i32;
 	fn read_date(ctx: i32) -> f64;

--- a/src/rust/vi.hentaivn/Cargo.toml
+++ b/src/rust/vi.hentaivn/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hentaivn"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/rust/vi.hentaivn/src/lib.rs
+++ b/src/rust/vi.hentaivn/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(let_chains)]
 extern crate alloc;
 mod parser;
 mod search;


### PR DESCRIPTION
closes #1013 

let chains are stable now, so building with a newer nightly rust will fail compilation when using `#![feature(let_chains)]`.

I didn't update source versions since there should be no source changes, only fixing compilation.