### PR TITLE
fix(ru.readmanga): update to official mirror, old domain returns 404

### DIFF
--- a/src/rust/ru.readmanga/res/source.json
+++ b/src/rust/ru.readmanga/res/source.json
@@ -3,8 +3,8 @@
 		"id": "ru.readmanga",
 		"lang": "ru",
 		"name": "ReadManga",
-		"version": 2,
-		"url": "https://readmanga.live",
+		"version": 3,
+		"url": "https://t.readmanga.io",
 		"nsfw": 1
 	},
 	"listings": [

--- a/src/rust/ru.readmanga/src/constants.rs
+++ b/src/rust/ru.readmanga/src/constants.rs
@@ -1,6 +1,6 @@
 use const_format::formatcp;
 
-pub const BASE_URL: &str = "https://readmanga.live";
+pub const BASE_URL: &str = "https://t.readmanga.io";
 pub const BASE_SEARCH_URL: &str = formatcp!("{}/{}", BASE_URL, "search/advancedResults?");
 
 pub const SEARCH_OFFSET_STEP: i32 = 50;


### PR DESCRIPTION
Checklist:
- [x] Updated source's version for individual source changes
- [x] Updated all sources' versions for template changes
- [x] Set appropriate `nsfw` value
- [x] Did not change `id` even if a source's name or language were changed
- [x] Tested the modifications by running it on the simulator or a test device