### PR TITLE
fix: update broken sources

### DIFF
--- a/src/rust/madara/sources/hentaicb/res/source.json
+++ b/src/rust/madara/sources/hentaicb/res/source.json
@@ -3,8 +3,8 @@
 		"id": "vi.hentaicube",
 		"lang": "vi",
 		"name": "HentaiCB",
-		"version": 8,
-		"url": "https://hentaicb.bar",
+		"version": 9,
+		"url": "https://2tencb.top",
 		"nsfw": 2
 	},
 	"listings": [

--- a/src/rust/madara/sources/hentaicb/src/lib.rs
+++ b/src/rust/madara/sources/hentaicb/src/lib.rs
@@ -12,7 +12,7 @@ use madara_template::template;
 
 fn get_data() -> template::MadaraSiteData {
 	let data: template::MadaraSiteData = template::MadaraSiteData {
-		base_url: String::from("https://hentaicb.bar"),
+		base_url: String::from("https://2tencb.top"),
 		lang: String::from("vi"),
 		source_path: String::from("read"),
 		image_selector: String::from(".reading-content .doc-truyen > img"),

--- a/src/rust/madara/sources/lilymanga/res/source.json
+++ b/src/rust/madara/sources/lilymanga/res/source.json
@@ -3,7 +3,7 @@
 		"id": "en.lilymanga",
 		"lang": "en",
 		"name": "Lily Manga",
-		"version": 8,
+		"version": 9,
 		"url": "https://lilymanga.net",
 		"nsfw": 2
 	},

--- a/src/rust/madara/sources/lilymanga/src/lib.rs
+++ b/src/rust/madara/sources/lilymanga/src/lib.rs
@@ -9,7 +9,8 @@ use madara_template::template;
 fn get_data() -> template::MadaraSiteData {
 	let data: template::MadaraSiteData = template::MadaraSiteData {
 		base_url: String::from("https://lilymanga.net"),
-		source_path: String::from("ys"),
+		source_path: String::from("gl"),
+		date_format: "dd.MM.yyyy".into(),
 		viewer: |html, _| {
 			let temp = html
 				.select("div.post-content_item:contains(Type) div.summary-content")

--- a/src/rust/madara/sources/resetscans/res/source.json
+++ b/src/rust/madara/sources/resetscans/res/source.json
@@ -3,8 +3,8 @@
 		"id": "en.resetscans",
 		"lang": "en",
 		"name": "Reset Scans",
-		"version": 13,
-		"url": "https://reset-scans.co",
+		"version": 14,
+		"url": "https://reset-scans.org",
 		"nsfw": 0
 	},
 	"listings": [

--- a/src/rust/madara/sources/resetscans/src/lib.rs
+++ b/src/rust/madara/sources/resetscans/src/lib.rs
@@ -8,7 +8,7 @@ use madara_template::template;
 
 fn get_data() -> template::MadaraSiteData {
 	let data: template::MadaraSiteData = template::MadaraSiteData {
-		base_url: "https://reset-scans.co".into(),
+		base_url: "https://reset-scans.org".into(),
 		description_selector: "div.description-summary".into(),
 		chapter_selector: "li.wp-manga-chapter > div:not(:has(a[href*=#]))".into(), // filter out locked chapters
 		alt_ajax: true,

--- a/src/rust/mangastream/sources/manhwalist/res/source.json
+++ b/src/rust/mangastream/sources/manhwalist/res/source.json
@@ -4,7 +4,7 @@
 		"lang": "id",
 		"name": "Manhwalist",
 		"version": 5,
-		"url": "https://manhwalist.xyz"
+		"url": "https://manhwalist02.site"
 	},
 	"listings": [
 		{

--- a/src/rust/mangastream/sources/manhwalist/src/lib.rs
+++ b/src/rust/mangastream/sources/manhwalist/src/lib.rs
@@ -8,7 +8,7 @@ use mangastream_template::template::MangaStreamSource;
 
 fn get_instance() -> MangaStreamSource {
 	MangaStreamSource {
-		base_url: String::from("https://manhwalist.xyz"),
+		base_url: String::from("https://manhwalist02.site"),
 		chapter_date_format: "MMMM d, yyyy",
 		locale: "en",
 		alt_pages: true,

--- a/src/rust/mangastream/sources/sushiscan/src/lib.rs
+++ b/src/rust/mangastream/sources/sushiscan/src/lib.rs
@@ -18,8 +18,9 @@ fn get_instance() -> MangaStreamSource {
 		manga_details_author: ".infotable tr:contains(Auteur) td:last-child",
 		manga_details_status: ".infotable tr:contains(Statut) td:last-child",
 		manga_details_type: ".infotable tr:contains(Type) td:last-child",
+		chapter_date_format: "d MMMM yyyy",
 		language: "fr",
-		locale: "fr-FR",
+		locale: "fr_FR",
 		..Default::default()
 	}
 }
@@ -101,7 +102,9 @@ fn get_page_list(_manga_id: String, id: String) -> Result<Vec<Page>> {
 
 #[modify_image_request]
 fn modify_image_request(request: Request) {
-	get_instance().modify_image_request(request)
+	request
+		.header("Referer", &format!("{BASE_URL}/catalogue"))
+		.header("User-Agent", USER_AGENT);
 }
 
 #[handle_url]


### PR DESCRIPTION
these were some broken sources that had very simple fixes, so I thought we might as well have them instead of removing.

updated:
- en.resetscans
- en.lilymanga
- vi.hentaicube: closes #983
- fr.sushiscan: no version increment, since there's already a newer version [here](https://github.com/Aidoku-Community/sources)
- id.manhwalist: no version increment, since there's already a newer version [here](https://github.com/Aidoku-Community/sources)